### PR TITLE
Added the section for a new deploy.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,14 +42,36 @@ jobs:
       - name: Generate deployment package zipfile
         run: zip -r deploy-${{ steps.format-time.outputs.replaced }}.zip * -x "**node_modules**" -x '*.git*'
 
-      - name: Deploy to EB
-        uses: einaregilsson/beanstalk-deploy@v20
-        with:
-          aws_access_key: ${{ env.AWS_ACCESS_KEY_ID }}
-          aws_secret_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          aws_session_token: ${{ github.event.inputs.session_token }}
-          application_name: deliberation
-          environment_name: Deliberation-env
-          version_label: "commit_${{ steps.format-time.outputs.replaced }}"
-          region: ${{ env.AWS_REGION }}
-          deployment_package: deploy-${{ steps.format-time.outputs.replaced }}.zip
+      ##
+
+
+      # Testing on Yingquan's bucket; copying to S3.
+      - name: Upload package to S3 bucket
+        run: aws s3 cp ${{ steps.format-time.outputs.replaced }}.zip s3://myawsbucket-staging-yl/
+
+      # Creating an EB Application Version
+      - name: Create new ElasticBeanstalk Application Version
+        run: |
+          aws elasticbeanstalk create-application-version \
+          --application-name deliberation \
+          --source-bundle S3Bucket="myawsbucket-staging-yl",S3Key="deploy-${{ steps.format-time.outputs.replaced }}.zip" \
+          --version-label "ver-${{ github.sha }}" \
+          --description "commit-sha-${{ github.sha }}"
+
+      # Deploy to EB
+      - name: Deploy new ElasticBeanstalk Application Version
+        run: aws elasticbeanstalk update-environment --environment-name Deliberation-1 --version-label "ver-${{ github.sha }}"
+
+
+      ## Old Deploy
+      # - name: Deploy to EB
+      #   uses: einaregilsson/beanstalk-deploy@v20
+      #   with:
+      #     aws_access_key: ${{ env.AWS_ACCESS_KEY_ID }}
+      #     aws_secret_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+      #     aws_session_token: ${{ github.event.inputs.session_token }}
+      #     application_name: deliberation
+      #     environment_name: Deliberation-env
+      #     version_label: "commit_${{ steps.format-time.outputs.replaced }}"
+      #     region: ${{ env.AWS_REGION }}
+      #     deployment_package: deploy-${{ steps.format-time.outputs.replaced }}.zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,11 +43,13 @@ jobs:
         run: zip -r deploy-${{ steps.format-time.outputs.replaced }}.zip * -x "**node_modules**" -x '*.git*'
 
       ##
-
-
+      
       # Testing on Yingquan's bucket; copying to S3.
       - name: Upload package to S3 bucket
         run: aws s3 cp ${{ steps.format-time.outputs.replaced }}.zip s3://myawsbucket-staging-yl/
+
+      # Create an EB environment
+      aws elasticbeanstalk create-environment --application-name deliberation --template-name v1 --version-label v1 --environment-name Deliberation-1
 
       # Creating an EB Application Version
       - name: Create new ElasticBeanstalk Application Version


### PR DESCRIPTION
@JamesPHoughton Please review the changes of the new GitHub Action. Specifically if I want to copy your **.zip** to s3, does `${{ steps.format-time.outputs.replaced }}` persist on lines: 43, 50 and 57. If I use your environment variable to copy to S3 and create an EB application version, is it the same timestamp or does the timestamp change?