### PR TITLE
Create exit step that immediately goes to the next page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -12,6 +12,7 @@ import TopicSurvey from "./intro-exit/Surveys/gov_reduce_income_inequality";
 import team_viability from "./intro-exit/Surveys/team_viability";
 import quality_control from "./intro-exit/Surveys/quality_control";
 import { PlayerIDForm } from './intro-exit/PlayerIDForm';
+import { ImmediateAdvance } from "./intro-exit/ImmediateAdvance";
 
 import { IRBConsent } from './intro-exit/IRBConsent';
 
@@ -38,6 +39,7 @@ export default function App() {
   ]
 
   const exitSteps = [
+    ImmediateAdvance,
     team_viability,
     quality_control
   ]

--- a/client/src/intro-exit/ImmediateAdvance.jsx
+++ b/client/src/intro-exit/ImmediateAdvance.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { useEffect } from "react";
+
+export function ImmediateAdvance ({ next }) {
+    useEffect(() => {
+        next()
+    })
+    return (
+        <h2>Redirecting...</h2>
+    )
+    
+}


### PR DESCRIPTION
The point of this page is that there is nothing in the tajriba.json that links the discussion ending to a participant.  For data analysis purposes, this step will allow us to get the time that the discussion ends so we can correctly calculate how long the team_viability survey takes participants to complete