### PR TITLE
Automate Version Update

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,25 @@
+name: Update JS Version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Update Version in index.html
+        working-directory: ./client
+        run: |
+          vtime=$(date +"%Y%m%d%H%M")
+          sed -i "s|version=[0-9]\+|version=${vtime}|g" index.html
+
+          git config --global user.name "Version Action"
+          git config --global user.email "version-control@wattslab.com"
+          git add index.html
+          git commit -m "Update Version"
+          git push

--- a/client/index.html
+++ b/client/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/main.jsx?version=202207251049"></script>
   </body>
 </html>


### PR DESCRIPTION
Force client browser to reload page by adding version number to main js script.
Version number is timestamp of merge to main.

I tested locally that the shell script to update the version number in index.html works. I'm not sure how to test the whole actions file since it only runs on push to main. Do you have any suggestions?