### PR TITLE
debugging no open batches breaking error

### DIFF
--- a/server/src/callbacks.js
+++ b/server/src/callbacks.js
@@ -396,15 +396,15 @@ Empirica.on("player", async (ctx, { player }) => {
     const participantData = await getParticipantData({ platformId });
     player.set("participantData", participantData);
 
-    player.set("batchId", batch.id);
-    player.set("introSequence", batch.get("introSequence"));
-    player.set("launchDate", batch.get("launchDate"));
+    player.set("batchId", batch?.id);
+    player.set("introSequence", batch?.get("introSequence"));
+    player.set("launchDate", batch?.get("launchDate"));
     player.set("timeArrived", Date.now());
     player.set("initialized", true);
 
     playersForParticipant.set(participantID, player);
 
-    console.log(`initializing player ${player.id} in batch ${batch.id}"`);
+    console.log(`initializing player ${player.id} in batch ${batch?.id}"`);
   }
 
   if (online.has(participantID)) {

--- a/server/src/getTreatments.js
+++ b/server/src/getTreatments.js
@@ -38,7 +38,7 @@ function validatePromptString({ filename, promptString }) {
   const promptName = metaData?.name;
   if (promptName !== filename) {
     throw new Error(
-      `Prompt name "${promptName}" does not match filename ${filename}`
+      `Prompt name "${promptName}" does not match filename "${filename}"`
     );
   }
   if (!prompt || prompt.length === 0) {


### PR DESCRIPTION
Server error when player initializes at the same time that a batch becomes unavailable.

``` bash
[deliberation-empirica] [2023-03-06 19:55:01] 19:55:01.763 ERR Error caught in "player" callback: [deliberation-empirica] [2023-03-06 19:55:01] 19:55:01.926 ERR TypeError: Cannot read properties of undefined (reading 'id')
[deliberation-empirica] [2023-03-06 19:55:01] 19:55:01.926 ERR   at Object.callback (/tmp/5278f4541c558c7a/src/callbacks.js:399:33)
[deliberation-empirica] [2023-03-06 19:55:01] 19:55:01.926 ERR   at <anonymous> (/tmp/5278f4541c558c7a/node_modules/@empirica/core/src/admin/cake.ts:229:15)
[deliberation-empirica] [2023-03-06 19:55:01] Creating datafile /participantData/av.jsonl
``` 