### PR TITLE
Draft terraform.tf

### DIFF
--- a/.github/workflows/deploy_aws_app_runner.yml
+++ b/.github/workflows/deploy_aws_app_runner.yml
@@ -1,6 +1,3 @@
-# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
-# More GitHub Actions for Azure: https://github.com/Azure/actions
-
 name: Deploy to AWS App runner
 
 on:
@@ -10,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.{{ secrets.AWS_REGION }}.amazonaws.com
+  ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
 
 jobs:
   build:

--- a/.github/workflows/deploy_aws_app_runner.yml
+++ b/.github/workflows/deploy_aws_app_runner.yml
@@ -1,0 +1,45 @@
+# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
+# More GitHub Actions for Azure: https://github.com/Azure/actions
+
+name: Deploy to AWS App runner
+
+on:
+  # push:
+  #   branches:
+  #     - main
+  workflow_dispatch:
+
+env:
+  ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.{{ secrets.AWS_REGION }}.amazonaws.com
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to AWS ECR
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.ECR_REGISTRY }}
+          username: ${{ secrets.AWS_DEPLOY_ACCESS_KEY }}
+          password: ${{ secrets.AWS_DEPLOY_SECRET_KEY }}
+
+      - name: Lowercase the repo name
+        run: echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+
+      - name: Build and push container image to registry
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          build-args: |
+            TEST_CONTROLS=disabled
+            BUILD_SHA=${{ github.sha }}
+          tags: |
+            ${{env.ECR_REGISTRY}}/${{ env.REPO }}:latest
+            ${{env.ECR_REGISTRY}}/${{ env.REPO }}:${{ github.sha }}
+          file: ./Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ tajriba.json
 testData/
 
 .vscode/
+.terraform
 
 # Logs
 logs
@@ -111,3 +112,4 @@ dist
 .DS_Store
 tmp.json
 temp.yaml
+.terraform.lock.hcl

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ dist
 tmp.json
 temp.yaml
 .terraform.lock.hcl
+*.tfstate
+*.tfstate.backup

--- a/ecs_service.tf
+++ b/ecs_service.tf
@@ -1,0 +1,105 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_security_group" "deliberation" {
+  name_prefix = "deliberation"
+}
+
+resource "aws_vpc" "deliberation" {
+}
+
+resource "aws_subnet" "deliberation" {
+    vpc_id = aws_vpc.deliberation.id
+}
+
+resource "aws_efs_file_system" "efs" {
+  creation_token = "efs"
+}
+
+resource "aws_efs_access_point" "efs" {
+    file_system_id = aws_efs_file_system.efs.id
+}
+
+resource "aws_efs_mount_target" "mount_target" {
+  file_system_id = aws_efs_file_system.efs.id
+  subnet_id      = aws_subnet.deliberation.id
+}
+
+resource "aws_cloudwatch_log_group" "deliberation-empirica-log-group" {
+    name = "/ecs/deliberation-empirica-logs"
+}
+
+resource "aws_cloudwatch_log_stream" "deliberation-empirica-log-stream" {
+    name = "deliberation-empirica-log-stream"
+    log_group_name = aws_cloudwatch_log_group.deliberation-empirica-log-group.name
+
+}
+
+resource "aws_ecs_task_definition" "deliberation-empirica-app" {
+  family                   = "deliberation-empirica-app"
+  container_definitions    = jsonencode([
+  {
+    name      = "deliberation-empirica-container",
+    image     = "ghcr.io/watts-lab/deliberation-empirica:latest", 
+    cpu       = 10,
+    memory    = 512,
+    essential = true,
+    portMappings = [
+        {
+        containerPort = 3000
+        hostPort      = 80
+        }
+    ]
+    mountPoints = [
+      {
+        sourceVolume  = "deliberation-data-volume"
+        containerPath = "/data"
+      }
+    ]
+    logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+            awslogs-group = aws_cloudwatch_log_group.deliberation-empirica-log-group.name,
+            awslogs-region = "us-east-1",
+            awslogs-stream-prefix = "ecs"
+        }
+    }
+  }
+  ])
+
+  volume {
+    name = "deliberation-data-volume"
+    efs_volume_configuration {
+      file_system_id          = aws_efs_file_system.efs.id
+      transit_encryption      = "ENABLED"
+      authorization_config {
+        access_point_id       = aws_efs_access_point.efs.id
+        iam                   = "ENABLED"
+      }
+    }
+  }
+
+
+}
+
+resource "aws_ecs_service" "deliberation-empirica-app" {
+  name            = "deliberation-empirica-app"
+  task_definition = aws_ecs_task_definition.deliberation-empirica-app.arn
+  desired_count   = 1
+
+  network_configuration {
+    security_groups = [aws_security_group.deliberation.id]
+    subnets         = [aws_subnet.deliberation.id]
+  }
+
+}
+
+
+
+resource "aws_lb_target_group" "example" {
+  name_prefix        = "delib"
+  port               = 80
+  protocol           = "HTTP"
+  target_type        = "ip"
+}

--- a/ecs_service.tf
+++ b/ecs_service.tf
@@ -1,16 +1,20 @@
 provider "aws" {
-  region = "us-east-1"
+  region  = "us-east-1"
+  profile = "aws-csslab-deliberation-seas-acct-PennAccountAdministrator"
 }
 
 resource "aws_security_group" "deliberation" {
   name_prefix = "deliberation"
+  vpc_id      = aws_vpc.deliberation.id
 }
 
 resource "aws_vpc" "deliberation" {
+  cidr_block = "10.0.0.0/16"
 }
 
 resource "aws_subnet" "deliberation" {
-    vpc_id = aws_vpc.deliberation.id
+  vpc_id = aws_vpc.deliberation.id
+  cidr_block = "10.0.0.0/16"
 }
 
 resource "aws_efs_file_system" "efs" {
@@ -18,7 +22,7 @@ resource "aws_efs_file_system" "efs" {
 }
 
 resource "aws_efs_access_point" "efs" {
-    file_system_id = aws_efs_file_system.efs.id
+  file_system_id = aws_efs_file_system.efs.id
 }
 
 resource "aws_efs_mount_target" "mount_target" {
@@ -27,55 +31,55 @@ resource "aws_efs_mount_target" "mount_target" {
 }
 
 resource "aws_cloudwatch_log_group" "deliberation-empirica-log-group" {
-    name = "/ecs/deliberation-empirica-logs"
+  name = "/ecs/deliberation-empirica-logs"
 }
 
 resource "aws_cloudwatch_log_stream" "deliberation-empirica-log-stream" {
-    name = "deliberation-empirica-log-stream"
-    log_group_name = aws_cloudwatch_log_group.deliberation-empirica-log-group.name
+  name           = "deliberation-empirica-log-stream"
+  log_group_name = aws_cloudwatch_log_group.deliberation-empirica-log-group.name
 
 }
 
 resource "aws_ecs_task_definition" "deliberation-empirica-app" {
-  family                   = "deliberation-empirica-app"
-  container_definitions    = jsonencode([
-  {
-    name      = "deliberation-empirica-container",
-    image     = "ghcr.io/watts-lab/deliberation-empirica:latest", 
-    cpu       = 10,
-    memory    = 512,
-    essential = true,
-    portMappings = [
+  family = "deliberation-empirica-app"
+  container_definitions = jsonencode([
+    {
+      name      = "deliberation-empirica-container",
+      image     = "ghcr.io/watts-lab/deliberation-empirica:latest",
+      cpu       = 10,
+      memory    = 512,
+      essential = true,
+      portMappings = [
         {
-        containerPort = 3000
-        hostPort      = 80
+          containerPort = 3000
+          hostPort      = 80
         }
-    ]
-    mountPoints = [
-      {
-        sourceVolume  = "deliberation-data-volume"
-        containerPath = "/data"
-      }
-    ]
-    logConfiguration = {
+      ]
+      mountPoints = [
+        {
+          sourceVolume  = "deliberation-data-volume"
+          containerPath = "/data"
+        }
+      ]
+      logConfiguration = {
         logDriver = "awslogs"
         options = {
-            awslogs-group = aws_cloudwatch_log_group.deliberation-empirica-log-group.name,
-            awslogs-region = "us-east-1",
-            awslogs-stream-prefix = "ecs"
+          awslogs-group         = aws_cloudwatch_log_group.deliberation-empirica-log-group.name,
+          awslogs-region        = "us-east-1",
+          awslogs-stream-prefix = "ecs"
         }
+      }
     }
-  }
   ])
 
   volume {
     name = "deliberation-data-volume"
     efs_volume_configuration {
-      file_system_id          = aws_efs_file_system.efs.id
-      transit_encryption      = "ENABLED"
+      file_system_id     = aws_efs_file_system.efs.id
+      transit_encryption = "ENABLED"
       authorization_config {
-        access_point_id       = aws_efs_access_point.efs.id
-        iam                   = "ENABLED"
+        access_point_id = aws_efs_access_point.efs.id
+        iam             = "ENABLED"
       }
     }
   }
@@ -95,11 +99,10 @@ resource "aws_ecs_service" "deliberation-empirica-app" {
 
 }
 
-
-
 resource "aws_lb_target_group" "example" {
-  name_prefix        = "delib"
-  port               = 80
-  protocol           = "HTTP"
-  target_type        = "ip"
+  name_prefix = "delib"
+  port        = 80
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.deliberation.id
 }

--- a/server/src/qualtricsFetch.js
+++ b/server/src/qualtricsFetch.js
@@ -1,3 +1,5 @@
+// Todo: use the "responses", "result" names we use in the other parts of the experiment
+
 import { get } from "axios";
 
 export async function getQualtricsData({ surveyId, sessionId }) {
@@ -21,22 +23,22 @@ export async function getQualtricsData({ surveyId, sessionId }) {
   };
 
   try {
-    const response = await get(URL, config);
+    const httpResponse = await get(URL, config);
     const {
       data: { result },
-    } = response;
+    } = httpResponse;
 
-    if (response.status === 200) {
+    if (httpResponse.status === 200) {
       // request succeeded
       return result;
     }
-    if (response.status === 202) {
+    if (httpResponse.status === 202) {
       // TODO: wait and try again?
       console.log("Qualtrics Data not Ready when requested");
     }
     console.log(
       `Fetched Qualtrics data from ${URL}, not sure what to do with it`,
-      response
+      httpResponse
     );
   } catch (err) {
     console.log(


### PR DESCRIPTION
Took a crack at this, aided largely by a LLM and docs. Really not convinced that all these resources are necessary.

The file validates fine, but when I run `terraform apply`, I get the following errors:

```bash
(base) jamesphoughton@Jamess-MBP-5 deliberation-empirica % terraform validate
Success! The configuration is valid.
```

```bash

(base) jamesphoughton@Jamess-MBP-5 deliberation-empirica % terraform apply

Terraform used the selected providers to generate the following execution plan. Resource
actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_cloudwatch_log_group.deliberation-empirica-log-group will be created
  + resource "aws_cloudwatch_log_group" "deliberation-empirica-log-group" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + name              = "/ecs/deliberation-empirica-logs"
      + name_prefix       = (known after apply)
      + retention_in_days = 0
      + skip_destroy      = false
      + tags_all          = (known after apply)
    }

  # aws_cloudwatch_log_stream.deliberation-empirica-log-stream will be created
  + resource "aws_cloudwatch_log_stream" "deliberation-empirica-log-stream" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + log_group_name = "/ecs/deliberation-empirica-logs"
      + name           = "deliberation-empirica-log-stream"
    }

  # aws_ecs_service.deliberation-empirica-app will be created
  + resource "aws_ecs_service" "deliberation-empirica-app" {
      + cluster                            = (known after apply)
      + deployment_maximum_percent         = 200
      + deployment_minimum_healthy_percent = 100
      + desired_count                      = 1
      + enable_ecs_managed_tags            = false
      + enable_execute_command             = false
      + iam_role                           = (known after apply)
      + id                                 = (known after apply)
      + launch_type                        = (known after apply)
      + name                               = "deliberation-empirica-app"
      + platform_version                   = (known after apply)
      + scheduling_strategy                = "REPLICA"
      + tags_all                           = (known after apply)
      + task_definition                    = (known after apply)
      + triggers                           = (known after apply)
      + wait_for_steady_state              = false

      + network_configuration {
          + assign_public_ip = false
          + security_groups  = (known after apply)
          + subnets          = (known after apply)
        }
    }

  # aws_ecs_task_definition.deliberation-empirica-app will be created
  + resource "aws_ecs_task_definition" "deliberation-empirica-app" {
      + arn                   = (known after apply)
      + arn_without_revision  = (known after apply)
      + container_definitions = jsonencode(
            [
              + {
                  + cpu              = 10
                  + essential        = true
                  + image            = "ghcr.io/watts-lab/deliberation-empirica:latest"
                  + logConfiguration = {
                      + logDriver = "awslogs"
                      + options   = {
                          + awslogs-group         = "/ecs/deliberation-empirica-logs"
                          + awslogs-region        = "us-east-1"
                          + awslogs-stream-prefix = "ecs"
                        }
                    }
                  + memory           = 512
                  + mountPoints      = [
                      + {
                          + containerPath = "/data"
                          + sourceVolume  = "deliberation-data-volume"
                        },
                    ]
                  + name             = "deliberation-empirica-container"
                  + portMappings     = [
                      + {
                          + containerPort = 3000
                          + hostPort      = 80
                        },
                    ]
                },
            ]
        )
      + family                = "deliberation-empirica-app"
      + id                    = (known after apply)
      + network_mode          = (known after apply)
      + revision              = (known after apply)
      + skip_destroy          = false
      + tags_all              = (known after apply)

      + volume {
          + name = "deliberation-data-volume"

          + efs_volume_configuration {
              + file_system_id     = (known after apply)
              + root_directory     = "/"
              + transit_encryption = "ENABLED"

              + authorization_config {
                  + access_point_id = (known after apply)
                  + iam             = "ENABLED"
                }
            }
        }
    }

  # aws_efs_access_point.efs will be created
  + resource "aws_efs_access_point" "efs" {
      + arn             = (known after apply)
      + file_system_arn = (known after apply)
      + file_system_id  = (known after apply)
      + id              = (known after apply)
      + owner_id        = (known after apply)
      + tags_all        = (known after apply)
    }

  # aws_efs_file_system.efs will be created
  + resource "aws_efs_file_system" "efs" {
      + arn                     = (known after apply)
      + availability_zone_id    = (known after apply)
      + availability_zone_name  = (known after apply)
      + creation_token          = "efs"
      + dns_name                = (known after apply)
      + encrypted               = (known after apply)
      + id                      = (known after apply)
      + kms_key_id              = (known after apply)
      + number_of_mount_targets = (known after apply)
      + owner_id                = (known after apply)
      + performance_mode        = (known after apply)
      + size_in_bytes           = (known after apply)
      + tags_all                = (known after apply)
      + throughput_mode         = "bursting"
    }

  # aws_efs_mount_target.mount_target will be created
  + resource "aws_efs_mount_target" "mount_target" {
      + availability_zone_id   = (known after apply)
      + availability_zone_name = (known after apply)
      + dns_name               = (known after apply)
      + file_system_arn        = (known after apply)
      + file_system_id         = (known after apply)
      + id                     = (known after apply)
      + ip_address             = (known after apply)
      + mount_target_dns_name  = (known after apply)
      + network_interface_id   = (known after apply)
      + owner_id               = (known after apply)
      + security_groups        = (known after apply)
      + subnet_id              = (known after apply)
    }

  # aws_lb_target_group.example will be created
  + resource "aws_lb_target_group" "example" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + connection_termination             = false
      + deregistration_delay               = "300"
      + id                                 = (known after apply)
      + ip_address_type                    = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancing_algorithm_type      = (known after apply)
      + load_balancing_cross_zone_enabled  = (known after apply)
      + name                               = (known after apply)
      + name_prefix                        = "delib"
      + port                               = 80
      + preserve_client_ip                 = (known after apply)
      + protocol                           = "HTTP"
      + protocol_version                   = (known after apply)
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags_all                           = (known after apply)
      + target_type                        = "ip"
    }

  # aws_security_group.deliberation will be created
  + resource "aws_security_group" "deliberation" {
      + arn                    = (known after apply)
      + description            = "Managed by Terraform"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "deliberation"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags_all               = (known after apply)
      + vpc_id                 = (known after apply)
    }

  # aws_subnet.deliberation will be created
  + resource "aws_subnet" "deliberation" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = (known after apply)
      + availability_zone_id                           = (known after apply)
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.deliberation will be created
  + resource "aws_vpc" "deliberation" {
      + arn                                  = (known after apply)
      + cidr_block                           = (known after apply)
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = (known after apply)
      + enable_classiclink_dns_support       = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags_all                             = (known after apply)
    }

Plan: 11 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_vpc.deliberation: Creating...
aws_lb_target_group.example: Creating...
aws_security_group.deliberation: Creating...
aws_cloudwatch_log_group.deliberation-empirica-log-group: Creating...
aws_efs_file_system.efs: Creating...
╷
│ Error: creating Security Group (deliberation20230414014949592400000001): UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message: v3NbV6pMaKcNGejTJjB4W7DO4Jl9ABCB5MHApTkVH_24tBP3gC4y7w9s4mqZh1O0GVldETF992Xu1SlvJt69AyKodtCSXJC6WLDPsHzdjEv4_ShXMKb0oHgKOnwcJ6lsK06oGSJP-9CvGohhAe6N4QnLWswxhXMHnAzhlQmF2LvabDwbcZhKMREpvf7FJolpqJcb8pa3NTgndLsGN-poymvjXZ-12phH0OtGoBSEGBvioVoObKfmmrAZR3J8kImzaTPJ_RfT3zgY67e6fciST_JFdS1tdtBI_BvmW3BfgdrR9GqJQ-OMxEQ7BNAWR9YKQUpw4Oil1if3fL8Azvvgw-wVSUzlCX25LKqbkGi_O7SQKStyAqwPuSfLxDDFnGpdtOMbnaLn9KJs5xZoN5If3iTyBJ9XimjwLHDY4a_Fzpo5ihRSXYO_cfDUeV3uEXkQS9xGCCiZNe7pMDptKOdmG7ee8_ZuYC9cQ4G2fgEK0QPflv5zBr791P2Mjlh8mZsTUctJBoLML6K4THr7fgoDtn7h09jU5vB1jQ
│       status code: 403, request id: 49552996-7667-477c-81ce-80732f74c68c
│ 
│   with aws_security_group.deliberation,
│   on ecs_service.tf line 5, in resource "aws_security_group" "deliberation":
│    5: resource "aws_security_group" "deliberation" {
│ 
╵
╷
│ Error: creating EC2 VPC: UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message: pLsro_Af3XL8TA6y-ZbdF4Z3xgQq7dxLIb3jW0GITH_7f0oiBZnPpMLlGt4YR5-KGe7eeKCKS-pZ2XuW5YgQ4enRsZaNYPL9CekZPg9W0tK3o8yN43jsaAEAhl-CDEpbJBfxtDCyyqNV_S3GGAaCUoPfpO7LObyp-MyexDAgdOAeboPrQMYRQ8LYKCm_G4qY4yEd2CJMrlxx34MJFhhgmv6EpXVKZv0Q9R2yITd4C2dbSepeRsEtzBFYyRfOW1631JzYIW2iwZ9aPbqJgkxK_8TiBUHWgwid0fb9CdF3T0Yu-PxCq2ZD9a2jaXYhnKPskRmJYvJ1vsGeK7fddEL7Jyf0tAJz5XTeGVwjvEzbmsDoH3bcti3W5LVCQpQ89HS6Fgv30mOCMUj0fwu32bsI8nocm9Okg2Pu6zAbyLa-S5eUEoQtknGJXaoByFfwI3NPXCuMlyHh3Fk2_CwNycD8FOKohD0ajbXbICClWQlo8ihDxxKTIhR5Ju1ZCk4dxDmG-rHnM-Ptd2UTxCyc1cc
│       status code: 403, request id: c0431824-cbce-4c9c-877a-e2708f04ec3e
│ 
│   with aws_vpc.deliberation,
│   on ecs_service.tf line 9, in resource "aws_vpc" "deliberation":
│    9: resource "aws_vpc" "deliberation" {
│ 
╵
╷
│ Error: creating EFS file system: AccessDeniedException: User: arn:aws:iam::941654414269:user/DeliberationDataDownload is not authorized to perform: elasticfilesystem:CreateFileSystem on the specified resource
│       status code: 403, request id: 1f0f9aeb-7525-4941-8d37-c3f6da3aca64
│ 
│   with aws_efs_file_system.efs,
│   on ecs_service.tf line 16, in resource "aws_efs_file_system" "efs":
│   16: resource "aws_efs_file_system" "efs" {
│ 
╵
╷
│ Error: creating CloudWatch Logs Log Group (/ecs/deliberation-empirica-logs): AccessDeniedException: User: arn:aws:iam::941654414269:user/DeliberationDataDownload is not authorized to perform: logs:CreateLogGroup on resource: arn:aws:logs:us-east-1:941654414269:log-group:/ecs/deliberation-empirica-logs:log-stream: because no identity-based policy allows the logs:CreateLogGroup action
│       status code: 400, request id: eda2c4e4-9aa1-4b72-a235-added37ad1e4
│ 
│   with aws_cloudwatch_log_group.deliberation-empirica-log-group,
│   on ecs_service.tf line 29, in resource "aws_cloudwatch_log_group" "deliberation-empirica-log-group":
│   29: resource "aws_cloudwatch_log_group" "deliberation-empirica-log-group" {
│ 
╵
╷
│ Error: reading ELBv2 Target Group (delib20230414014949592400000002): AccessDenied: User: arn:aws:iam::941654414269:user/DeliberationDataDownload is not authorized to perform: elasticloadbalancing:DescribeTargetGroups because no identity-based policy allows the elasticloadbalancing:DescribeTargetGroups action
│       status code: 403, request id: 7f6fdc24-46c7-42d5-bac4-739581af2468
│ 
│   with aws_lb_target_group.example,
│   on ecs_service.tf line 100, in resource "aws_lb_target_group" "example":
│  100: resource "aws_lb_target_group" "example" {
│ 
╵
```
cleanup gives:

```bash
(base) jamesphoughton@Jamess-MBP-5 deliberation-empirica % te
rraform show
The state file is empty. No resources are represented.
```

```bash
(base) jamesphoughton@Jamess-MBP-5 deliberation-empirica % te
rraform destroy

No changes. No objects need to be destroyed.

Either you have not created any objects yet or the existing
objects were already deleted outside of Terraform.

Destroy complete! Resources: 0 destroyed.
```