### PR TITLE
Deal with string/number input when checking for templates

### DIFF
--- a/server/src/preFlight/validateTreatmentFile.ts
+++ b/server/src/preFlight/validateTreatmentFile.ts
@@ -121,7 +121,7 @@ function altTemplateContext<T extends z.ZodTypeAny>(baseSchema: T) {
       return; 
     }
     // Determine schema based on presence of `template` field
-    const schemaToUse = 'template' in data ? templateContextSchema : baseSchema;
+    const schemaToUse = typeof data === 'object' && 'template' in data ? templateContextSchema : baseSchema;
     // console.log("data", data, "schemaToUse", 'template' in data ? "template" : "base");
     const result = schemaToUse.safeParse(data);
 


### PR DESCRIPTION
Throws Type Error when input is introSequences: STRING (e.g. introSequences: error) because the 'in' operator requires an object (i.e. array or object). Adding this check will result in an error that is easier to understand for user ("expected array, received string)