### PR TITLE
fix(ReportMissing): clear timeout timer on stage change

### DIFF
--- a/cypress/fixtures/mockCDN/projects/example/cypress.treatments.yaml
+++ b/cypress/fixtures/mockCDN/projects/example/cypress.treatments.yaml
@@ -78,10 +78,15 @@ treatments:
           showNickname: true
           showTitle: true
         elements:
-          - projects/example/multipleChoice.md
+          - type: prompt
+            file: projects/example/multipleChoice.md
+          - type: submitButton
       - name: test proceed to next stage after dropout
         duration: 3600
         elements:
+          - type: prompt
+            file: projects/example/testDisplay00.md
+            name: stage2Identifier
           - type: prompt
             file: projects/example/multipleChoiceColors.md
             conditions:


### PR DESCRIPTION
## Summary

Fixes #1109 - Missing participant timeout was persisting across stage transitions and prematurely ending subsequent stages.

## Problem

When a participant reported a missing player, a timeout timer was set. This timer was only cleared when enough players checked in (passedCheckIn() returned true). However, if the stage ended for other reasons (e.g., players submitted normally), the timer remained pending and would fire on the subsequent stage, causing it to prematurely end.

## Solution

Added a `useEffect` cleanup in `ReportParticipantMissing` that triggers when `progressLabel` changes (stage transition):
- Clears any pending timeout via `clearTimeout()`
- Resets `waitingToastOpen` and `timeResponseRequested` state

Used a ref (`responseTimerRef`) to avoid stale closure issues in the cleanup function.

## Testing

- Added regression test `it("clears timeout timer on stage end")` in `11_Dropouts.js`
- Modified `cypress_dropouts` treatment to add submit button to stage 1
- All existing tests pass

## Files Changed

- `client/src/components/ReportMissing.jsx` - Timer cleanup on stage change
- `cypress/e2e/11_Dropouts.js` - Regression test
- `cypress/fixtures/mockCDN/projects/example/cypress.treatments.yaml` - Treatment modifications