### PR TITLE
feat(discussion): add showReportMissing option to disable report button

### DIFF
--- a/client/src/Stage.jsx
+++ b/client/src/Stage.jsx
@@ -110,6 +110,7 @@ export function Stage() {
           showNickname={discussion.showNickname ?? true}
           showTitle={discussion.showTitle}
           showSelfView={discussion.showSelfView ?? true}
+          showReportMissing={discussion.showReportMissing ?? true}
           layout={discussion.layout}
           rooms={discussion.rooms}
           reactionEmojisAvailable={discussion.reactionEmojisAvailable || []}

--- a/client/src/call/Tray.jsx
+++ b/client/src/call/Tray.jsx
@@ -17,7 +17,7 @@ import {
 import { Button } from "../components/Button";
 import { useReportMissing } from "../components/ReportMissing";
 
-export function Tray() {
+export function Tray({ showReportMissing = true }) {
   // ------------------- read Daily device state ---------------------
   const callObject = useDaily();
 
@@ -85,15 +85,17 @@ export function Tray() {
         </div>
         <div className="flex flex-1 items-center justify-center" />
         <div className="flex flex-1 items-center justify-end">
-          <Button
-            handleClick={openReportMissing}
-            testId="reportMissing"
-            primary
-            className="flex items-center gap-2 whitespace-nowrap px-4 py-3"
-          >
-            <MissingParticipant />
-            <span>Report Missing Participant</span>
-          </Button>
+          {showReportMissing && (
+            <Button
+              handleClick={openReportMissing}
+              testId="reportMissing"
+              primary
+              className="flex items-center gap-2 whitespace-nowrap px-4 py-3"
+            >
+              <MissingParticipant />
+              <span>Report Missing Participant</span>
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/client/src/call/VideoCall.jsx
+++ b/client/src/call/VideoCall.jsx
@@ -20,6 +20,7 @@ export function VideoCall({
   showNickname,
   showTitle,
   showSelfView = true,
+  showReportMissing = true,
   layout,
   rooms,
 }) {
@@ -167,17 +168,17 @@ export function VideoCall({
 
     const handleDeviceError =
       (type) =>
-      (ev = {}) => {
-        const rawMessage =
-          typeof ev.errorMsg === "string"
-            ? ev.errorMsg
-            : ev?.errorMsg?.message || ev?.error?.message;
+        (ev = {}) => {
+          const rawMessage =
+            typeof ev.errorMsg === "string"
+              ? ev.errorMsg
+              : ev?.errorMsg?.message || ev?.error?.message;
 
-        setDeviceError({
-          type,
-          message: rawMessage || null,
-        });
-      };
+          setDeviceError({
+            type,
+            message: rawMessage || null,
+          });
+        };
 
     const fatalHandler = handleDeviceError("fatal-devices-error");
     const cameraHandler = handleDeviceError("camera-error");
@@ -310,7 +311,7 @@ export function VideoCall({
                 rooms={rooms}
               />
             </div>
-            <Tray />
+            <Tray showReportMissing={showReportMissing} />
           </>
         )}
       </div>

--- a/client/src/elements/Discussion.jsx
+++ b/client/src/elements/Discussion.jsx
@@ -11,6 +11,7 @@ export function Discussion({
   showNickname,
   showTitle,
   showSelfView = true,
+  showReportMissing = true,
   layout,
   rooms,
   reactionEmojisAvailable,
@@ -55,6 +56,7 @@ export function Discussion({
               showNickname={showNickname}
               showTitle={showTitle}
               showSelfView={showSelfView}
+              showReportMissing={showReportMissing}
               layout={layout}
               rooms={rooms}
             />

--- a/cypress/fixtures/mockCDN/projects/example/cypress.treatments.yaml
+++ b/cypress/fixtures/mockCDN/projects/example/cypress.treatments.yaml
@@ -107,6 +107,22 @@ treatments:
             file: projects/example/multipleChoiceWizards.md
           - type: submitButton
 
+  - name: cypress_dropouts_no_report_button
+    desc: Cypress testing dropouts with report button hidden
+    playerCount: 2
+    gameStages:
+      - name: test hidden report missing button
+        duration: 3600
+        discussion:
+          chatType: video
+          showNickname: true
+          showTitle: true
+          showReportMissing: false
+        elements:
+          - type: prompt
+            file: projects/example/multipleChoice.md
+          - type: submitButton
+
   - name: cypress3_load_test
     desc: Cypress testing with lots of players and rapid interaction in the same game
     playerCount: 8

--- a/docs/study-design/discussion-options.md
+++ b/docs/study-design/discussion-options.md
@@ -56,6 +56,7 @@ The default videocall layout uses a responsive grid that adjusts the number of c
 Within this default, you can configure:
 
 - **`showSelfView`** (Optional, default `true`): Hide/show the participant’s own tile.
+- **`showReportMissing`** (Optional, default `true`): Show/hide the "Report Missing Participant" button. Set to `false` for breakout room scenarios where the automatic stage-advance behavior is undesirable.
 - **`rooms`**: (Optional, defaults to include all participants). Define breakout rooms by listing which study positions (e.g. 0, 1, 2, ...) should be included in each room. If `rooms` is included, all players who are shown the discussion component (i.e., are included in `showToPositions` or excluded from `hideFromPositions`) must be assigned to exactly one room.
 
 ```yaml

--- a/server/src/preFlight/validateTreatmentFile.ts
+++ b/server/src/preFlight/validateTreatmentFile.ts
@@ -272,6 +272,7 @@ export const discussionSchema = z
     showNickname: z.boolean(),
     showTitle: z.boolean(),
     showSelfView: z.boolean().optional().default(true),
+    showReportMissing: z.boolean().optional().default(true),
     reactionEmojisAvailable: z.array(z.string()).optional(),
     reactToSelf: z.boolean().optional(),
     numReactionsPerMessage: z.number().int().nonnegative().optional(),
@@ -851,20 +852,20 @@ export const elementSchema = altTemplateContext(
 
     const schemaToUse = hasTypeKey
       ? z.discriminatedUnion("type", [
-          audioSchema,
-          displaySchema,
-          imageSchema,
-          promptSchema,
-          qualtricsSchema,
-          separatorSchema,
-          sharedNotepadSchema,
-          submitButtonSchema,
-          surveySchema,
-          talkMeterSchema,
-          timerSchema,
-          videoSchema,
-          trackedLinkSchema,
-        ])
+        audioSchema,
+        displaySchema,
+        imageSchema,
+        promptSchema,
+        qualtricsSchema,
+        separatorSchema,
+        sharedNotepadSchema,
+        submitButtonSchema,
+        surveySchema,
+        talkMeterSchema,
+        timerSchema,
+        videoSchema,
+        trackedLinkSchema,
+      ])
       : promptShorthandSchema;
 
     const result = schemaToUse.safeParse(data);
@@ -1331,7 +1332,7 @@ export const templateContentSchema = z.any().superRefine((data, ctx) => {
           issue.expected === "string" &&
           issue.received === "object" &&
           issue.message ===
-            "promptShorthandSchema expects a string, but received object."
+          "promptShorthandSchema expects a string, but received object."
       );
 
       if (discriminatorIssue !== undefined) {


### PR DESCRIPTION
## Summary
Implements #1108: Adds a new `showReportMissing` configuration option for video discussions that allows researchers to hide the "Report Missing Participant" button.

## Motivation
This is useful for breakout room scenarios where:
- The automatic stage-advance behavior is undesirable
- Researchers want to avoid terminating an entire stage when most rooms are having successful conversations

## Changes
- **Zod Schema** (`validateTreatmentFile.ts`): Added `showReportMissing` optional boolean (default: `true`)
- **Component Threading**: Passed prop through `Stage.jsx` → `Discussion.jsx` → `VideoCall.jsx` → `Tray.jsx`
- **Conditional Rendering**: Button only renders when `showReportMissing` is `true`
- **Documentation**: Updated `discussion-options.md` with new option
- **Testing**: Added `cypress_dropouts_no_report_button` treatment and Cypress test

## Usage
```yaml
discussion:
  chatType: video
  showNickname: true
  showTitle: true
  showReportMissing: false  # hides the Report Missing Participant button
```

## Testing
- [x] Server build passes
- [x] Lint passes for modified files
- [x] Added Cypress test verifying button is hidden when `showReportMissing: false`

Closes #1108