### PR TITLE
fix: suppress idle detection when player has submitted stage

### DIFF
--- a/client/src/components/ConditionalRender.jsx
+++ b/client/src/components/ConditionalRender.jsx
@@ -10,6 +10,7 @@ import { detect } from "detect-browser";
 import { Button } from "./Button";
 import { Alert } from "./Alert";
 import { compare, useReferenceValues } from "./hooks";
+import { useIdleContext } from "./IdleProvider";
 
 // If test controls are enabled,
 // returns a button to toggle the contents on or off (initially off)
@@ -175,8 +176,24 @@ function RecursiveConditionalRender({ conditions, children }) {
 export function SubmissionConditionalRender({ children }) {
   const player = usePlayer();
   const players = usePlayers();
+  const { setAllowIdle } = useIdleContext();
 
-  if (player?.stage?.get("submit")) {
+  const isSubmitted = player?.stage?.get("submit");
+
+  useEffect(() => {
+    if (isSubmitted) {
+      setAllowIdle(true);
+      console.log("Set Allow Idle (stage submitted)");
+    }
+    return () => {
+      if (isSubmitted) {
+        setAllowIdle(false);
+        console.log("Clear Allow Idle (stage transition)");
+      }
+    };
+  }, [isSubmitted, setAllowIdle]);
+
+  if (isSubmitted) {
     if (!players || players.length === 1) {
       return <Loading />;
     }


### PR DESCRIPTION
## Summary
When a player submits their stage and is waiting for others, they will no longer trigger the idle detection system (chime + modal after 60 seconds of inactivity).

## Problem
After a player submits a stage, they see a "Please wait for other participant(s)" screen. If they go idle while waiting (which is expected since there's nothing for them to do), the idle detection system would:
1. Play an annoying chime sound
2. Show a modal saying "You seem idle... we don't want to keep others waiting"

This was frustrating because the player had already done their part.

## Solution
Modified `SubmissionConditionalRender` in `ConditionalRender.jsx` to call `setAllowIdle(true)` when the player has submitted, following the same pattern used in:
- `Lobby.jsx` - while waiting for group matching  
- `Countdown.jsx` - while waiting for session start
- `Debrief.jsx` - while reading debrief content

## Testing
- All 21 existing unit tests pass
- Manual testing can be done by submitting before other players and waiting 60+ seconds

Fixes #1116