### PR TITLE
fix(call): self-view display and subscription repair improvements

### DIFF
--- a/client/src/call/Tile.jsx
+++ b/client/src/call/Tile.jsx
@@ -34,13 +34,19 @@ export function Tile({ source, media, pixels }) {
   const audioState = useAudioTrack(dailyId);
   const username = useParticipantProperty(dailyId, "user_name"); // disappears if the player disconnects
 
-  // New flags for connection state
+  // For local tiles (self-view), we don't "subscribe" to our own tracks - they're
+  // always available locally. The `subscribed` property only applies to remote tracks.
+  const isLocalTile = source.type === "self";
+
+  // Connection state flags
   const isVideoConnected = !!videoState;
-  const isVideoSubscribed = videoState?.subscribed === true;
+  // For local tiles, treat as always "subscribed" since subscription doesn't apply
+  const isVideoSubscribed = isLocalTile || videoState?.subscribed === true;
   const isVideoMuted = videoState?.isOff;
 
   const isAudioConnected = !!audioState;
-  const isAudioSubscribed = audioState?.subscribed === true;
+  // For local tiles, treat as always "subscribed" since subscription doesn't apply
+  const isAudioSubscribed = isLocalTile || audioState?.subscribed === true;
   const isAudioMuted = audioState?.isOff;
 
   // ------------------- size tile to layout-provided pixels ---------------------

--- a/client/src/call/layouts/defaultResponsiveLayout.js
+++ b/client/src/call/layouts/defaultResponsiveLayout.js
@@ -116,7 +116,5 @@ export const defaultResponsiveLayout = ({
     })),
   };
 
-  console.log("Computed default responsive layout:", newLayout);
-
   return newLayout;
 };


### PR DESCRIPTION
## Summary
- Fix self-view showing "Waiting for participant to connect..." instead of the user's webcam feed
- Improve subscription repair mechanism reliability with cooldown and track state checks
- Remove excessive console logging from layout computation

## Changes
- **Tile.jsx**: Skip subscription check for local tiles since local tracks don't use the subscription model
- **Call.jsx**: Add 3-second cooldown after repair attempts; only subscribe when tracks are in a subscribable state
- **defaultResponsiveLayout.js**: Remove `console.log` that fired on every layout computation

## Context
This fixes issues introduced in #1132 where:
1. The self-view tile incorrectly showed "Waiting for participant to connect..." because it was checking `subscribed` status on local tracks (which don't have subscriptions)
2. The repair mechanism was repeatedly trying to fix subscriptions without giving Daily time to process, and without checking if tracks were ready

## Test plan
- [ ] Self-view displays correctly when joining a call
- [ ] Self-view shows "Video Muted" when camera is off (not "Waiting...")
- [ ] Remote participants can see each other's video/audio
- [ ] Late joiners get subscribed correctly
- [ ] Console is not spammed with layout logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)