### PR TITLE
fix(cypress): update IP API mock to use ipwho.is instead of ip-api.com

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -363,20 +363,42 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add("interceptIpApis", () => {
-  cy.intercept("http://ip-api.com/json/", {
+  // Updated to match ipwho.is API (changed from ip-api.com in PR #811)
+  cy.intercept("https://ipwho.is*", {
     statusCode: 200,
     body: {
-      status: "success",
-      countryCode: "US",
-      timezone: "America/New_York",
-      query: "1.1.1.1",
+      success: true,
+      ip: "8.8.8.8", // Use an IP that's NOT in the VPN list so isKnownVpn will be false
+      type: "IPv4",
+      continent: "North America",
+      continent_code: "NA",
+      country: "United States",
+      country_code: "US",
+      region: "New York",
+      region_code: "NY",
+      city: "New York",
+      latitude: 40.7128,
+      longitude: -74.0060,
+      timezone: {
+        id: "America/New_York",
+        abbr: "EST",
+        is_dst: false,
+        offset: -18000,
+        utc: "-05:00",
+      },
+      security: {
+        vpn: false,
+        proxy: false,
+        tor: false,
+        relay: false,
+      },
     },
-  }).as("ip-api");
+  }).as("ipwho-api");
   cy.intercept(
     "https://raw.githubusercontent.com/X4BNet/lists_vpn/main/output/vpn/ipv4.txt",
     {
       statusCode: 200,
-      body: "1.1.1.1",
+      body: "1.1.1.1", // VPN list contains 1.1.1.1, but IP is 8.8.8.8, so isKnownVpn will be false
     }
   ).as("vpn-list");
 });


### PR DESCRIPTION
Fixes #1145

## Problem
Cypress tests were failing intermittently because the `interceptIpApis()` command was mocking the old `ip-api.com` endpoint while production code uses `ipwho.is` (changed in PR #811). This caused tests to make real HTTP requests which could timeout or fail, leaving `connectionInfo.isKnownVpn` undefined and breaking conditional renders like TestDisplay32.

## Root Cause
- **Production code** (hooks.js:79): Uses `axios.get("https://ipwho.is")`
- **Cypress mock** (commands.js:366): Was intercepting `http://ip-api.com/json/` ❌
- This mismatch meant the intercept never matched, causing real HTTP requests

## Changes
Updated `cy.interceptIpApis()` in cypress/support/commands.js to:
1. Intercept `https://ipwho.is*` instead of `http://ip-api.com/json/`
2. Use ipwho.is API response format with all required fields:
   - `country_code`, `timezone.id`, `timezone.utc`, `ip`
3. Set mock IP to "8.8.8.8" (not in VPN list) so `isKnownVpn` will be `false`

## Verification
Existing tests (e.g., TestDisplay32 check in 01_Normal_Paths_Omnibus.js) will now work correctly because:
- Mock provides all fields expected by `useConnectionInfo()` hook
- `isKnownVpn` correctly evaluates to `false` (8.8.8.8 not in VPN list)
- Conditional renders that depend on connection info will display as expected

## Test Plan
- [x] Verified production code uses `https://ipwho.is`
- [x] Updated mock to match ipwho.is API response structure
- [x] Confirmed mock IP (8.8.8.8) is not in VPN list (1.1.1.1) so `isKnownVpn` will be `false`
- [ ] Run full Cypress test suite to verify TestDisplay32 and similar tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)