### PR TITLE
test: disable AGC for Daily video calls

### DIFF
--- a/client/src/call/VideoCall.jsx
+++ b/client/src/call/VideoCall.jsx
@@ -144,6 +144,22 @@ export function VideoCall({
       try {
         await callObject.join({ url: roomUrl });
         console.log("Joined Daily room:", roomUrl);
+
+        // TEMP: Disable autoGainControl to test if it's causing quiet audio issues.
+        // Keep echo cancellation and noise suppression enabled.
+        // See: https://docs.daily.co/reference/daily-js/instance-methods/set-input-devices-async
+        try {
+          await callObject.setInputDevicesAsync({
+            audioSource: {
+              autoGainControl: false,
+              echoCancellation: true,
+              noiseSuppression: true,
+            },
+          });
+          console.log("Disabled AGC via setInputDevicesAsync");
+        } catch (agcErr) {
+          console.warn("Failed to disable AGC:", agcErr);
+        }
       } catch (err) {
         console.error("Error joining Daily room", roomUrl, err);
       } finally {


### PR DESCRIPTION
## Summary
- Disable browser `autoGainControl` for Daily.co video calls to test if it's causing quiet audio
- Keeps `echoCancellation` and `noiseSuppression` enabled
- Applied after joining the Daily room via `setInputDevicesAsync`

## Context
Users are reporting very quiet audio in calls. This may be caused by:
1. The loopback check disabling AGC and affecting subsequent calls (separate PR #1163)
2. Browser AGC being overly aggressive and reducing volume

This PR tests option 2 by explicitly disabling AGC for the actual calls.

## Test plan
- [ ] Deploy and test with real participants
- [ ] Compare audio levels with this change vs without
- [ ] If audio improves, consider making this permanent (or configurable)

## Notes
This is a temporary diagnostic change marked with `TEMP:` comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)