### PR TITLE
fix(recording): stop recording when video stages end

### DIFF
--- a/server/src/callbacks.js
+++ b/server/src/callbacks.js
@@ -445,8 +445,12 @@ Empirica.onStageEnded(({ stage }) => {
   const discussion = stage?.get("discussion");
   const callStarted = stage?.get("callStarted");
   const config = stage.currentGame.batch.get("validatedConfig");
-  if (!discussion || !callStarted || config.videoStorage !== "none") return;
-  stopRecording(stage.currentGame.get("dailyRoomName"));
+
+  // Only stop recording if this was a video stage with recording enabled
+  // (mirrors the condition in the callStarted handler that starts recording)
+  if (discussion?.chatType === "video" && callStarted && config.videoStorage !== "none") {
+    stopRecording(stage.currentGame.get("dailyRoomName"));
+  }
 });
 
 // ------------------- Player callbacks ---------------------------


### PR DESCRIPTION
## Summary

- Fixes inverted condition in `onStageEnded` that prevented `stopRecording()` from ever being called
- The condition returned early when `videoStorage !== "none"` (i.e., when recording was enabled), meaning recordings continued until game end

## Root Cause

The original code:
```javascript
if (!discussion || !callStarted || config.videoStorage !== "none") return;
stopRecording(stage.currentGame.get("dailyRoomName"));
```

Should have been `=== "none"` to skip stopping when there's no recording. Instead, it skipped stopping when there WAS recording.

## Impact

Recordings continued past stage boundaries. For participants with disconnections spanning stage transitions, their tracks could extend well past the expected stage duration because:
1. Client-side `leave()` was delayed due to disconnect
2. Server-side `stopRecording()` never ran (this bug)
3. Recording only stopped when `closeRoom()` was called at game end

## Test plan

- [ ] Deploy to test environment
- [ ] Run a batch with video stages
- [ ] Verify recordings stop at stage end (check Daily dashboard or raw track durations)

Fixes #1175

🤖 Generated with [Claude Code](https://claude.ai/code)