### PR TITLE
fix(call): warn in console when Daily room URL is missing

### DIFF
--- a/client/src/call/VideoCall.jsx
+++ b/client/src/call/VideoCall.jsx
@@ -173,6 +173,20 @@ export function VideoCall({
   const joiningMeetingRef = useRef(false);
 
   useEffect(() => {
+    if (roomUrl) return undefined; // URL arrived — nothing to warn about
+    // Delay the warning to avoid firing during the brief window between the game
+    // starting and the server finishing the async createRoom() call.
+    const timer = setTimeout(() => {
+      console.warn(
+        "[VideoCall] No Daily room URL after 5 s (game.get('dailyUrl') is still empty).",
+        "In a test environment, check that DAILY_APIKEY is configured on the server.",
+        "In production, the server may have failed to create the Daily room."
+      );
+    }, 5000);
+    return () => clearTimeout(timer);
+  }, [roomUrl]);
+
+  useEffect(() => {
     if (!callObject || callObject.isDestroyed?.() || !roomUrl) return undefined;
     // `roomUrl` is only populated when the batch config had checkVideo/checkAudio enabled.
     // When both flags are false we skip Daily entirely (handy for layout demos), so this

--- a/server/src/callbacks.js
+++ b/server/src/callbacks.js
@@ -365,7 +365,7 @@ Empirica.on("game", "start", async (ctx, { game, start }) => {
       info("Creating daily room for game", game.id);
       const roomName = batch.get("label").slice(0, 20) + game.id.slice(-6);
       game.set("recordingsFolder", roomName);
-      const room = await createRoom(roomName, config.videoStorage); // fails on this
+      const room = await createRoom(roomName, config.videoStorage);
       game.set("dailyUrl", room?.url);
       game.set("dailyRoomName", room?.name);
     }


### PR DESCRIPTION
## Summary

- Adds a delayed `console.warn` (5 s) in `VideoCall` when `game.get('dailyUrl')` is still empty after game start, making it immediately obvious in DevTools when `DAILY_APIKEY` is not configured on the server or the server failed to create the Daily room
- The delay avoids false positives during the brief async window between game start and the server finishing `createRoom()` — the warning cancels itself if the URL arrives in time (the normal case)
- Removes a stale `// fails on this` debug comment from `callbacks.js`

## Background

Investigated a case where both participants had `meetingState: "loaded"` in Sentry diagnostics, meaning neither ever joined the Daily call. Root cause: `game.get("dailyUrl")` was null, so VideoCall's join effect bailed immediately. This happens in test environments where `DAILY_APIKEY` is not set (or set to `"none"`), causing `createRoom()` to silently return `undefined`. Previously there was no visible signal in the UI or console to explain why the video area was blank.

## Test plan

- [ ] Start a game with a valid `DAILY_APIKEY` — no warning should appear in the console
- [ ] Start a game with `DAILY_APIKEY=none` — after ~5 s, a `[VideoCall]` warning should appear in the browser DevTools console
- [ ] Confirm no visible change to the participant UI in either case

🤖 Generated with [Claude Code](https://claude.com/claude-code)