### PR TITLE
fix(setup): wait for video track playable before running network checks

### DIFF
--- a/client/src/intro-exit/setup/CameraCheck.jsx
+++ b/client/src/intro-exit/setup/CameraCheck.jsx
@@ -159,12 +159,17 @@ export function CameraCheck({ setWebcamStatus, setErrorMessage }) {
           setWebsocketStatus={setWebsocketStatus}
         />
       )}
-      {videoStatus === "started" && (
-        <TestCallQuality
-          callQualityStatus={callQualityStatus}
-          setCallQualityStatus={setCallQualityStatus}
-        />
-      )}
+      {/* Only start call quality after network and websocket tests are done.
+          Daily throws if testNetworkConnectivity() is called while testCallQuality()
+          is in progress, so we must not let them overlap. */}
+      {videoStatus === "started" &&
+        !["waiting", "retrying"].includes(networkStatus) &&
+        !["waiting", "retrying"].includes(websocketStatus) && (
+          <TestCallQuality
+            callQualityStatus={callQualityStatus}
+            setCallQualityStatus={setCallQualityStatus}
+          />
+        )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Root cause of network connectivity errors**: `startCamera()` resolves when the camera *device* is initialized, but `persistentTrack` (required by `testNetworkConnectivity`) is only populated once the track reaches `"playable"` state. Calling `testNetworkConnectivity(undefined)` was throwing an error. Fixed by listening for Daily's `local-track-started` event before signalling video readiness, with a fallback playable-state check and a 10s timeout if the track never fires.
- **Race between network retry and call quality test**: Daily throws if `testNetworkConnectivity()` is called while `testCallQuality()` is in progress. When the network test failed and retried, it was racing with call quality starting simultaneously. Fixed by only rendering `TestCallQuality` once network and websocket tests reach a terminal state.
- **Defensive fix**: Added `?.` to `video?.persistentTrack` optional chain in `TestNetworkConnectivity`.

Closes #1149, #1151

## Test plan

- [ ] Run through webcam setup on a normal machine — network/websocket/call quality all pass, user proceeds
- [ ] Confirm in browser console that `videoTrackStarted` event fires before network checks begin
- [ ] Simulate slow track start (e.g. dev tools throttling) — confirm checks wait rather than error
- [ ] Confirm that if network test needs to retry, call quality test hasn't started yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)