### PR TITLE
Improve retry log message in useConnectionInfo to include context

### DIFF
--- a/client/src/components/hooks.js
+++ b/client/src/components/hooks.js
@@ -101,7 +101,7 @@ export function useConnectionInfo() {
         console.error(error.message);
         if (retryCount < maxRetries) {
           retryCount += 1;
-          console.log(`Retrying... (${retryCount}/${maxRetries})`);
+          console.log(`Retrying connection info (country/VPN check)... (${retryCount}/${maxRetries})`);
           setTimeout(loadData, retryDelay);
         }
       }


### PR DESCRIPTION
The generic "Retrying... (1/3)" message gave no indication of what was being retried. Updated to "Retrying connection info (country/VPN check)..." so developers (and users reading the console) can immediately identify the operation.

Closes #1193

https://claude.ai/code/session_011qx1voXAU9ZHfY8yiD5TYw