### PR TITLE
fix(playwright): resolve 7 flaky Chromium tests — timing and IPC races

### DIFF
--- a/playwright/component-tests/video-call/mocked/AudioContext.ct.jsx
+++ b/playwright/component-tests/video-call/mocked/AudioContext.ct.jsx
@@ -137,7 +137,7 @@ test.describe('AudioContext banner behavior', () => {
     await enableButton.click();
 
     // Banner should disappear after resume
-    await expect(page.locator('text=Audio is paused')).not.toBeVisible({ timeout: 5000 });
+    await expect(page.locator('text=Audio is paused')).not.toBeVisible({ timeout: 10000 });
   });
 
   /**

--- a/playwright/component-tests/video-call/mocked/DeviceAlignmentLogs.ct.jsx
+++ b/playwright/component-tests/video-call/mocked/DeviceAlignmentLogs.ct.jsx
@@ -66,7 +66,9 @@ test.describe('Device Alignment Log Behavior', () => {
 
     const component = await mount(<VideoCall showSelfView />, { hooksConfig: config });
     await expect(component).toBeVisible({ timeout: 15000 });
-    await page.waitForTimeout(500);
+    // Longer settle wait for absence assertion — can't poll for "still 0" so we wait
+    // for effects to fully drain under CPU load before checking for spurious logs
+    await page.waitForTimeout(1000);
 
     // Should NOT have any device-changed events (alignment guarded by camerasLoaded check)
     const deviceChangedLogs = console.matching(/Logged stage event: device-changed/);

--- a/playwright/component-tests/video-call/mocked/PermissionMonitoring.ct.jsx
+++ b/playwright/component-tests/video-call/mocked/PermissionMonitoring.ct.jsx
@@ -174,10 +174,13 @@ test.describe('Permission Monitoring', () => {
     await waitForPermHandlers(page);
 
     await page.evaluate(() => window.triggerPermChange('microphone', 'prompt'));
-    await page.waitForTimeout(200);
 
+    // Poll until the console message propagates through Playwright IPC
+    await expect.poll(
+      () => consoleCapture.matching(/\[Permissions\] microphone permission changed/i).length,
+      { timeout: 5000 },
+    ).toBeGreaterThanOrEqual(1);
     const warnLogs = consoleCapture.matching(/\[Permissions\] microphone permission changed/i);
-    expect(warnLogs.length).toBeGreaterThanOrEqual(1);
     expect(warnLogs[0].text).toContain('prompt');
   });
 
@@ -207,13 +210,16 @@ test.describe('Permission Monitoring', () => {
 
     // Revoke camera permission entirely
     await page.evaluate(() => window.triggerPermChange('camera', 'denied'));
-    await page.waitForTimeout(200);
 
-    // Should have both a warning and an error
-    const warnLogs = consoleCapture.matching(/\[Permissions\] camera permission changed/i);
-    const errorLogs = consoleCapture.matching(/\[Permissions\] camera permission DENIED/i);
-    expect(warnLogs.length).toBeGreaterThanOrEqual(1);
-    expect(errorLogs.length).toBeGreaterThanOrEqual(1);
+    // Poll until both console messages propagate through Playwright IPC
+    await expect.poll(
+      () => consoleCapture.matching(/\[Permissions\] camera permission changed/i).length,
+      { timeout: 5000 },
+    ).toBeGreaterThanOrEqual(1);
+    await expect.poll(
+      () => consoleCapture.matching(/\[Permissions\] camera permission DENIED/i).length,
+      { timeout: 5000 },
+    ).toBeGreaterThanOrEqual(1);
   });
 
   /**

--- a/playwright/component-tests/video-call/mocked/VideoCall.recoveryWorkflows.ct.jsx
+++ b/playwright/component-tests/video-call/mocked/VideoCall.recoveryWorkflows.ct.jsx
@@ -737,12 +737,13 @@ test.describe('W7: Proactive track monitoring', () => {
       return calls.some((c) => c.audioDeviceId !== undefined);
     }, { timeout: 20000 }).toBe(true);
 
-    // Should have logged a Sentry breadcrumb about the track recovery
-    const captures = await page.evaluate(() => window.mockSentryCaptures);
-    const trackBreadcrumb = captures.breadcrumbs.find(
-      (b) => /track/i.test(b.category) || /track.*ended|auto.*recover/i.test(b.message)
-    );
-    expect(trackBreadcrumb).toBeTruthy();
+    // Poll for the Sentry breadcrumb — it may arrive slightly after setInputDevicesAsync
+    await expect.poll(async () => {
+      const captures = await page.evaluate(() => window.mockSentryCaptures);
+      return captures.breadcrumbs.some(
+        (b) => /track/i.test(b.category) || /track.*ended|auto.*recover/i.test(b.message),
+      );
+    }, { timeout: 5000 }).toBe(true);
   });
 });
 
@@ -789,8 +790,9 @@ test.describe('Device error render storm prevention', () => {
     // A fallback banner must appear (not a modal)
     await expect(page.locator('[data-test="deviceFallbackBanner"]')).toBeVisible({ timeout: 5000 });
 
-    // Give async effects time to settle
-    await page.waitForTimeout(500);
+    // Flush two animation frames to drain all pending microtasks and React effects
+    // before asserting absence of error logs (can't poll for "still 0")
+    await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r))));
 
     // not-found errors now route to banners, not UserMediaError — so no
     // [Media Error] console output is expected. Allow 0.

--- a/playwright/component-tests/video-call/mocked/VideoCall.responsiveLayout.ct.jsx
+++ b/playwright/component-tests/video-call/mocked/VideoCall.responsiveLayout.ct.jsx
@@ -216,8 +216,8 @@ test.describe('VideoCall - Responsive Layout', () => {
       // Resize to tablet
       await page.setViewportSize({ width: 768, height: 1024 });
 
-      // Wait a bit for ResizeObserver to trigger
-      await page.waitForTimeout(500);
+      // Double rAF flush: ensures ResizeObserver callback and resulting React render complete
+      await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r))));
 
       // Tiles should still be visible after resize
       await expect(component.locator('[data-test="callTile"]')).toHaveCount(3);
@@ -228,7 +228,7 @@ test.describe('VideoCall - Responsive Layout', () => {
 
       // Resize to mobile
       await page.setViewportSize({ width: 375, height: 667 });
-      await page.waitForTimeout(500);
+      await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r))));
 
       // Tiles should STILL be visible
       await expect(component.locator('[data-test="callTile"]')).toHaveCount(3);


### PR DESCRIPTION
Closes #1218

## Summary

- **PERM-002/003**: Replace `waitForTimeout(200)` + static `expect` with `expect.poll()` — console messages arrive async through Playwright IPC and were not guaranteed to be present within 200ms under load
- **WF7-003**: Poll for Sentry breadcrumb instead of asserting immediately after `setInputDevicesAsync` resolves — the breadcrumb write is a separate async step
- **WF-STORM-001**: Replace `waitForTimeout(500)` with double `requestAnimationFrame` flush to drain all pending microtasks and React effects before absence assertions
- **AUDIO-003**: Increase `not.toBeVisible` timeout 5s → 10s to accommodate slower React state propagation under CPU contention
- **LOG-002**: Increase settle wait 500ms → 1000ms — absence assertions (`toHaveLength(0)`) cannot be polled, need time for effects to drain
- **Responsive layout**: Replace both `waitForTimeout(500)` after `setViewportSize` with double rAF to ensure ResizeObserver and layout pass complete before asserting tile visibility

All 7 tests verified passing locally on Chromium.

## Test plan
- [ ] All 7 previously-flaky tests pass on Chromium
- [ ] Full video-call/mocked suite still passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)