### PR TITLE
fix: skip speaker selection on Safari < 18.4

### DIFF
--- a/client/src/intro-exit/setup/HeadphonesCheck.jsx
+++ b/client/src/intro-exit/setup/HeadphonesCheck.jsx
@@ -5,17 +5,44 @@ import { Button } from "../../components/Button";
 import { RadioGroup } from "../../components/RadioGroup";
 import { Select } from "../../components/Select";
 
+// Safari < 18.4 and iOS Safari do not support enumerating audio output devices.
+// When setSinkId is unavailable, we skip the speaker picker and let the OS
+// route audio to the system default output.  Evaluated inside the component
+// (not at module level) so tests can manipulate the prototype before mount.
+function checkCanSelectSpeaker() {
+  return (
+    typeof HTMLMediaElement !== "undefined" &&
+    typeof HTMLMediaElement.prototype.setSinkId === "function"
+  );
+}
+
 export function HeadphonesCheck({ setHeadphonesStatus, setErrorMessage }) {
   const player = usePlayer();
+  const canSelectSpeaker = checkCanSelectSpeaker();
   const [headphonesReady, setHeadphonesReady] = useState(false);
   const [soundPlayed, setSoundPlayed] = useState(false);
   const [soundSelected, setSoundSelected] = useState("");
-  const [speakerSelectionMode, setSpeakerSelectionMode] = useState("select"); // "select" | "testing"
+  const [speakerSelectionMode, setSpeakerSelectionMode] = useState(
+    canSelectSpeaker ? "select" : "testing"
+  ); // "select" | "testing"
   const [activeSpeaker, setActiveSpeaker] = useState(null);
   const [speakerIteration, setSpeakerIteration] = useState(0);
   const [noDevicesTimeout, setNoDevicesTimeout] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
   const audioRef = useRef(null);
+
+  useEffect(() => {
+    if (!canSelectSpeaker) {
+      player.append("setupSteps", {
+        step: "headphonesCheck",
+        event: "speakerSelectionSkipped",
+        value: "setSinkId not supported",
+        errors: [],
+        debug: { userAgent: navigator.userAgent },
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }, [player, canSelectSpeaker]);
 
   useEffect(() => {
     if (soundPlayed && soundSelected) {
@@ -39,6 +66,11 @@ export function HeadphonesCheck({ setHeadphonesStatus, setErrorMessage }) {
   const devices = useDevices();
 
   useEffect(() => {
+    // Only treat empty speakers as an error when the browser supports
+    // enumeration. Safari < 18.4 never returns audiooutput devices, so an
+    // empty list is expected — not a failure.
+    if (!canSelectSpeaker) return undefined;
+
     let timer;
     if (devices?.speakers?.length === 0) {
       timer = setTimeout(() => {
@@ -48,7 +80,7 @@ export function HeadphonesCheck({ setHeadphonesStatus, setErrorMessage }) {
       setNoDevicesTimeout(false);
     }
     return () => clearTimeout(timer);
-  }, [devices]);
+  }, [devices, canSelectSpeaker]);
 
   useEffect(() => {
     if (noDevicesTimeout) {
@@ -163,7 +195,7 @@ export function HeadphonesCheck({ setHeadphonesStatus, setErrorMessage }) {
           </Button>
         </section>
 
-        {headphonesReady && (
+        {headphonesReady && canSelectSpeaker && (
           <section>
             <h2>🎛 Step 2: Select those headphones</h2>
             {speakerSelectionMode === "testing" && activeSpeaker ? (
@@ -195,7 +227,12 @@ export function HeadphonesCheck({ setHeadphonesStatus, setErrorMessage }) {
 
         {headphonesReady && speakerSelectionMode === "testing" && (
           <section>
-            <h2>🔊 Step 3: Make sure you can hear </h2>
+            <h2>🔊 Step {canSelectSpeaker ? "3" : "2"}: Make sure you can hear </h2>
+            {!canSelectSpeaker && (
+              <p className="text-sm text-gray-600 mb-2">
+                Your browser will use the system default audio output.
+              </p>
+            )}
             <p>Press play and tell us which sound you heard.</p>
             <div className="flex items-center gap-3">
               <Button testId="playSound" handleClick={chime} className="">
@@ -232,7 +269,9 @@ export function HeadphonesCheck({ setHeadphonesStatus, setErrorMessage }) {
                 <ul>
                   <li>Are your headphones connected or paired?</li>
                   <li>Is the volume turned up?</li>
-                  <li>Is this device selected as the output above?</li>
+                  {canSelectSpeaker && (
+                    <li>Is this device selected as the output above?</li>
+                  )}
                 </ul>
                 <p>After checking these, please play the sound again.</p>
               </>

--- a/playwright/component-tests/equipment-check/HeadphonesCheck.ct.jsx
+++ b/playwright/component-tests/equipment-check/HeadphonesCheck.ct.jsx
@@ -22,6 +22,9 @@ import { HeadphonesCheck } from '../../../client/src/intro-exit/setup/Headphones
  *   HC-009  Play button sets status to "started" (for stall timer)
  *   HC-010  Playing indicator appears when audio plays and disappears when ended
  *   HC-011  play() rejection sets status to "fail" with error message
+ *   HC-012  Safari: speaker selection is skipped when setSinkId unavailable
+ *   HC-013  Safari: no-speakers does not trigger fail (no timeout)
+ *   HC-014  Safari: correct sound identification still passes
  *
  * Mock setup:
  *   - MockEmpiricaProvider provides usePlayer()
@@ -373,4 +376,112 @@ test('HC-011: play rejection sets fail', async ({ mount, page }) => {
 
   await expect.poll(() => latestStatus).toBe('fail');
   expect(latestError).toBe('Could not play test sound.');
+});
+
+// ---------------------------------------------------------------------------
+// Safari / no-setSinkId tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove setSinkId from HTMLMediaElement.prototype BEFORE mounting the
+ * component, so canSelectSpeaker evaluates to false.  Also mocks play().
+ */
+async function installAudioMocksWithoutSinkId(page, { playRejects = false } = {}) {
+  await page.evaluate((opts) => {
+    window._audioPlayCalls = [];
+    window._setSinkIdCalls = [];
+
+    // Remove setSinkId so the component detects no speaker selection support
+    delete HTMLMediaElement.prototype.setSinkId;
+
+    HTMLMediaElement.prototype.play = function mockPlay() {
+      window._audioPlayCalls.push({ src: this.currentSrc || this.src });
+      if (opts.playRejects) {
+        const err = new DOMException('NotAllowedError', 'NotAllowedError');
+        return Promise.reject(err);
+      }
+      const el = this;
+      setTimeout(() => el.dispatchEvent(new Event('playing')), 10);
+      window._lastAudioElement = el;
+      return Promise.resolve();
+    };
+
+    HTMLMediaElement.prototype.pause = function mockPause() {
+      this.dispatchEvent(new Event('pause'));
+    };
+  }, { playRejects });
+}
+
+/** HC-012: Speaker selection is skipped when setSinkId is unavailable */
+test('HC-012: Safari skips speaker selection', async ({ mount, page }) => {
+  await installAudioMocksWithoutSinkId(page);
+
+  await mount(
+    <HeadphonesCheck
+      setHeadphonesStatus={() => {}}
+      setErrorMessage={() => {}}
+    />,
+    { hooksConfig: hooksConfig() },
+  );
+
+  // Step 2 (speaker select) should NOT appear even after confirming headphones
+  await page.locator('button:has-text("I have headphones on")').click();
+  await expect(page.locator('[data-test="speakerSelect"]')).not.toBeVisible();
+
+  // Step 2 (sound test) should appear directly — note the step number is "2" not "3"
+  await expect(page.locator('[data-test="playSound"]')).toBeVisible();
+  await expect(page.locator('text=system default audio output')).toBeVisible();
+});
+
+/** HC-013: No speakers does NOT trigger fail when setSinkId unavailable */
+test('HC-013: Safari no-speakers does not fail', async ({ mount, page }) => {
+  await installAudioMocksWithoutSinkId(page);
+
+  let latestStatus = 'waiting';
+  let latestError = null;
+  await mount(
+    <HeadphonesCheck
+      setHeadphonesStatus={(s) => { latestStatus = s; }}
+      setErrorMessage={(m) => { latestError = m; }}
+    />,
+    {
+      hooksConfig: hooksConfig({
+        daily: { devices: { speakers: [], microphones: [], cameras: [] } },
+      }),
+    },
+  );
+
+  // Wait well past the 4s timeout — should NOT fail
+  await page.waitForTimeout(5000);
+  expect(latestStatus).not.toBe('fail');
+  expect(latestError).toBeNull();
+});
+
+/** HC-014: Safari flow still passes on correct sound identification */
+test('HC-014: Safari correct sound passes', async ({ mount, page }) => {
+  await installAudioMocksWithoutSinkId(page);
+
+  let latestStatus = 'waiting';
+  await mount(
+    <HeadphonesCheck
+      setHeadphonesStatus={(s) => { latestStatus = s; }}
+      setErrorMessage={() => {}}
+    />,
+    { hooksConfig: hooksConfig() },
+  );
+
+  // Step 1: confirm headphones
+  await page.locator('button:has-text("I have headphones on")').click();
+
+  // Step 2 (sound test) appears directly — no speaker selection needed
+  await expect(page.locator('[data-test="playSound"]')).toBeVisible();
+
+  // Play sound
+  await page.locator('[data-test="playSound"]').click();
+  await expect(page.locator('[data-test="soundSelect"]')).toBeVisible();
+
+  // Select correct answer
+  await page.locator('[data-test="soundSelect"] input[value="clock"]').check();
+
+  await expect.poll(() => latestStatus).toBe('pass');
 });


### PR DESCRIPTION
## Summary
- Safari < 18.4 doesn't support `enumerateDevices()` for audio output or `setSinkId()`, so the speaker picker is meaningless on these browsers
- `HeadphonesCheck` was treating empty speakers as a hardware failure, triggering a 4-second timeout → fail → restart → infinite loop (Sentry issue QZ, 14 restarts from one Safari 17.6 user)
- Now detects `setSinkId` support and skips the speaker picker on unsupported browsers, going straight from "put on headphones" to "play sound test" using the system default output

## Test plan
- [x] All 11 existing HeadphonesCheck tests pass (HC-001 through HC-011)
- [x] HC-012: Speaker selection skipped when `setSinkId` unavailable
- [x] HC-013: Empty speakers does NOT trigger fail timeout on Safari
- [x] HC-014: Full Safari flow (headphones → play → identify → pass) works
- [x] 42 tests pass across Chromium, Firefox, and WebKit
- [x] ESLint clean on modified file

Closes #1232

🤖 Generated with [Claude Code](https://claude.com/claude-code)