### PR TITLE
fix: show RadioGroup immediately on Play click, log audioPlaying

### DIFF
--- a/client/src/intro-exit/setup/HeadphonesCheck.jsx
+++ b/client/src/intro-exit/setup/HeadphonesCheck.jsx
@@ -138,7 +138,16 @@ export function HeadphonesCheck({ setHeadphonesStatus, setErrorMessage }) {
   useEffect(() => {
     const audio = audioRef.current;
     if (!audio) return undefined;
-    const onPlaying = () => setIsPlaying(true);
+    const onPlaying = () => {
+      setIsPlaying(true);
+      player.append("setupSteps", {
+        step: "headphonesCheck",
+        event: "audioPlaying",
+        errors: [],
+        debug: {},
+        timestamp: new Date().toISOString(),
+      });
+    };
     const onEnded = () => setIsPlaying(false);
     const onPause = () => setIsPlaying(false);
     audio.addEventListener("playing", onPlaying);
@@ -149,17 +158,19 @@ export function HeadphonesCheck({ setHeadphonesStatus, setErrorMessage }) {
       audio.removeEventListener("ended", onEnded);
       audio.removeEventListener("pause", onPause);
     };
-  }, []);
+  }, [player]);
 
   const chime = () => {
     if (audioRef.current) {
       setHeadphonesStatus("started");
+      // Show the RadioGroup immediately so the user can respond even if
+      // play() hangs or the sound doesn't reach their ears.
+      setSoundPlayed(true);
       audioRef.current.currentTime = 0;
       audioRef.current
         .play()
         .then(() => {
           console.log(`Playing Chime`);
-          setSoundPlayed(true);
         })
         .catch((error) => {
           console.error("Error playing chime:", error);


### PR DESCRIPTION
## Summary
- RadioGroup was gated on `play()` resolving — if the promise hung, the user was stuck with no way to respond (no radio options visible, stall timeout fires after 15s)
- Now shows the radio options immediately when Play is clicked, so users can select "I did not hear anything" even if `play()` hangs
- Adds an `audioPlaying` setupStep log when the browser's `playing` event fires, so future investigations can distinguish "sound never played" from "user didn't see the options"

**Sentry context:** DELIBERATION-EMPIRICA-R6 — 4 headphone stall events where `headphonesStatus: "started"` with no radio selection, trigger `stallTimeout`

## Test plan
- [x] All 42 HeadphonesCheck tests pass (14 tests × 3 browsers)
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)