### PR TITLE
fix(call): debounce Daily join + orphaned join cleanup + recording retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ tajriba.json
 .vscode/
 
 reference/
+sentry-exports/
 
 # Logs
 logs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Admin UI: `http://localhost:3000/admin`
 ## Tools
 
 - **GitHub**: Use `gh` CLI for all GitHub workflows — viewing issues, creating PRs, reading and responding to PR review comments. Paste issue/PR URLs or numbers directly into the conversation.
-- **Sentry**: Sentry MCP is installed. Use it to fetch error events, look up issues by ID, search for recent errors, etc.
+- **Sentry**: `sentry-cli` is installed and authenticated (`~/.sentryclirc`). Org: `watts-lab`, project: `deliberation-empirica`. Use it to list events, query issues, etc. For full event JSON exports, use the Sentry web API with the same auth token. Sentry MCP is also configured but may need re-authentication.
 
 ## Component Tests (Playwright)
 

--- a/client/src/call/hooks/useCallLifecycle.js
+++ b/client/src/call/hooks/useCallLifecycle.js
@@ -88,9 +88,9 @@ export function useCallLifecycle(callObject, roomUrl, player) {
       // corrupting the callObject state for subsequent video stages.
       // 150ms is imperceptible to users but longer than any observed transient
       // mount, and long enough for the previous leave() to complete.
-      // See issue #1236.
+      // See issue #1226.
       await new Promise((resolve) => {
-        inlineTimers.push(setTimeout(resolve, 150));
+        setTimeout(resolve, 150);
       });
       if (unmountedRef.current) {
         console.log("[VideoCall] Join debounce: component unmounted during delay, skipping join");
@@ -98,8 +98,8 @@ export function useCallLifecycle(callObject, roomUrl, player) {
       }
 
       const meetingState = callObject.meetingState?.();
-      if (meetingState === "joined-meeting" || joiningMeetingRef.current) {
-        console.warn("[VideoCall] joinRoom skipped — already in meeting or joining", {
+      if (meetingState === "joined-meeting" || meetingState === "joining" || joiningMeetingRef.current) {
+        console.warn("[VideoCall] joinRoom skipped", {
           meetingState,
           joiningMeetingRef: joiningMeetingRef.current,
         });
@@ -225,11 +225,12 @@ export function useCallLifecycle(callObject, roomUrl, player) {
       const state = callObject.meetingState?.();
 
       if (
-        // state === "joining" ||
         state === "joined-meeting" ||
         state === "loaded"
       ) {
-        // only leave if we are in the process of joining or already joined
+        // Only call leave() once the meeting has fully joined/loaded; we skip
+        // leave() for state === "joining" (handled below) to avoid forcing a
+        // leave mid-join.
         console.log("[VideoCall] Leaving Daily room", { state });
         callObject.leave();
       } else if (state === "joining") {

--- a/client/src/call/hooks/useCallLifecycle.js
+++ b/client/src/call/hooks/useCallLifecycle.js
@@ -143,7 +143,6 @@ export function useCallLifecycle(callObject, roomUrl, player) {
         // so the callObject doesn't stay stuck in "joined-meeting" on a stale room.
         if (unmountedRef.current) {
           console.warn("[VideoCall] Orphaned join detected — leaving immediately", {
-            roomUrl,
             durationMs: joinDuration,
           });
           callObject.leave();
@@ -154,7 +153,6 @@ export function useCallLifecycle(callObject, roomUrl, player) {
         setJoinStalled(false);
         blurredDuringJoinRef.current = false;
         console.log("[VideoCall] Joined Daily room", {
-          roomUrl,
           durationMs: joinDuration,
           hasFocus: document.hasFocus(),
           visibilityState: document.visibilityState,
@@ -206,7 +204,7 @@ export function useCallLifecycle(callObject, roomUrl, player) {
           console.warn("Failed to attempt AGC disable:", agcErr);
         }
       } catch (err) {
-        console.error("Error joining Daily room", roomUrl, err, {
+        console.error("Error joining Daily room", err, {
           meetingState: callObject.meetingState?.(),
         });
       } finally {
@@ -232,13 +230,10 @@ export function useCallLifecycle(callObject, roomUrl, player) {
         state === "loaded"
       ) {
         // only leave if we are in the process of joining or already joined
-        console.log("[VideoCall] Leaving Daily room", { state, roomUrl });
+        console.log("[VideoCall] Leaving Daily room", { state });
         callObject.leave();
       } else if (state === "joining") {
-        console.warn("[VideoCall] Cleanup: callObject is mid-join, leave() skipped", {
-          state,
-          roomUrl,
-        });
+        console.warn("[VideoCall] Cleanup: callObject is mid-join, leave() skipped");
       }
     };
     // `player` is intentionally excluded: position is read once at join time and

--- a/client/src/call/hooks/useCallLifecycle.js
+++ b/client/src/call/hooks/useCallLifecycle.js
@@ -25,6 +25,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 export function useCallLifecycle(callObject, roomUrl, player) {
   const joiningMeetingRef = useRef(false);
   const joinedRoomUrlRef = useRef(null); // track which room the callObject last joined
+  const unmountedRef = useRef(false); // track unmount to handle orphaned joins (#1226)
   // For stall detection (issue #1187) - track if join is taking too long due to blur
   const joinStartTimeRef = useRef(null);
   const blurredDuringJoinRef = useRef(false);
@@ -49,6 +50,8 @@ export function useCallLifecycle(callObject, roomUrl, player) {
     // `roomUrl` is only populated when the batch config had checkVideo/checkAudio enabled.
     // When both flags are false we skip Daily entirely (handy for layout demos), so this
     // effect bails before trying to join a non-existent room.
+
+    unmountedRef.current = false;
 
     // Track blur events during join to detect stalled joins
     // Track inline timeout IDs so cleanup can clear them on unmount
@@ -78,6 +81,23 @@ export function useCallLifecycle(callObject, roomUrl, player) {
     }, 5000);
 
     const joinRoom = async () => {
+      // Debounce: wait briefly before joining to avoid spurious joins during
+      // transient mounts. During stage transitions, Empirica can briefly render
+      // a VideoCall component (~36ms) for a non-video stage before React
+      // reconciliation unmounts it. Without this delay, the transient mount
+      // calls join() while the previous stage's cleanup is mid-leave(),
+      // corrupting the callObject state for subsequent video stages.
+      // 150ms is imperceptible to users but longer than any observed transient
+      // mount, and long enough for the previous leave() to complete.
+      // See issue #1236.
+      await new Promise((resolve) => {
+        inlineTimers.push(setTimeout(resolve, 150));
+      });
+      if (unmountedRef.current) {
+        console.log("[VideoCall] Join debounce: component unmounted during delay, skipping join");
+        return;
+      }
+
       const meetingState = callObject.meetingState?.();
       if (meetingState === "joined-meeting" || joiningMeetingRef.current) {
         console.warn("[VideoCall] joinRoom skipped — already in meeting or joining", {
@@ -120,6 +140,20 @@ export function useCallLifecycle(callObject, roomUrl, player) {
         });
         const joinDuration = Date.now() - joinStartTime;
         joinedRoomUrlRef.current = roomUrl;
+
+        // Orphaned join detection (#1226): if the component unmounted while
+        // join() was in flight, the cleanup couldn't call leave() because
+        // meetingState was "joining". Now that join completed, leave immediately
+        // so the callObject doesn't stay stuck in "joined-meeting" on a stale room.
+        if (unmountedRef.current) {
+          console.warn("[VideoCall] Orphaned join detected — leaving immediately", {
+            roomUrl,
+            durationMs: joinDuration,
+          });
+          callObject.leave();
+          return;
+        }
+
         // Join succeeded - clear stalled state
         setJoinStalled(false);
         blurredDuringJoinRef.current = false;
@@ -186,6 +220,7 @@ export function useCallLifecycle(callObject, roomUrl, player) {
 
     return () => {
       // cleanup on unmount or roomUrl change
+      unmountedRef.current = true;
       clearTimeout(stallTimer);
       inlineTimers.forEach(clearTimeout);
       window.removeEventListener("blur", handleBlurDuringJoin);

--- a/client/src/call/hooks/useCallLifecycle.js
+++ b/client/src/call/hooks/useCallLifecycle.js
@@ -24,6 +24,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
  */
 export function useCallLifecycle(callObject, roomUrl, player) {
   const joiningMeetingRef = useRef(false);
+  const joinedRoomUrlRef = useRef(null); // track which room the callObject last joined
   // For stall detection (issue #1187) - track if join is taking too long due to blur
   const joinStartTimeRef = useRef(null);
   const blurredDuringJoinRef = useRef(false);
@@ -82,7 +83,8 @@ export function useCallLifecycle(callObject, roomUrl, player) {
         console.warn("[VideoCall] joinRoom skipped — already in meeting or joining", {
           meetingState,
           joiningMeetingRef: joiningMeetingRef.current,
-          roomUrl,
+          requestedRoomUrl: roomUrl,
+          joinedRoomUrl: joinedRoomUrlRef.current,
         });
         return;
       }
@@ -117,6 +119,7 @@ export function useCallLifecycle(callObject, roomUrl, player) {
           userData: position != null ? { position } : undefined,
         });
         const joinDuration = Date.now() - joinStartTime;
+        joinedRoomUrlRef.current = roomUrl;
         // Join succeeded - clear stalled state
         setJoinStalled(false);
         blurredDuringJoinRef.current = false;

--- a/client/src/call/hooks/useCallLifecycle.js
+++ b/client/src/call/hooks/useCallLifecycle.js
@@ -24,7 +24,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
  */
 export function useCallLifecycle(callObject, roomUrl, player) {
   const joiningMeetingRef = useRef(false);
-  const joinedRoomUrlRef = useRef(null); // track which room the callObject last joined
   const unmountedRef = useRef(false); // track unmount to handle orphaned joins (#1226)
   // For stall detection (issue #1187) - track if join is taking too long due to blur
   const joinStartTimeRef = useRef(null);
@@ -103,8 +102,6 @@ export function useCallLifecycle(callObject, roomUrl, player) {
         console.warn("[VideoCall] joinRoom skipped — already in meeting or joining", {
           meetingState,
           joiningMeetingRef: joiningMeetingRef.current,
-          requestedRoomUrl: roomUrl,
-          joinedRoomUrl: joinedRoomUrlRef.current,
         });
         return;
       }
@@ -139,7 +136,6 @@ export function useCallLifecycle(callObject, roomUrl, player) {
           userData: position != null ? { position } : undefined,
         });
         const joinDuration = Date.now() - joinStartTime;
-        joinedRoomUrlRef.current = roomUrl;
 
         // Orphaned join detection (#1226): if the component unmounted while
         // join() was in flight, the cleanup couldn't call leave() because

--- a/client/src/call/hooks/useCallLifecycle.js
+++ b/client/src/call/hooks/useCallLifecycle.js
@@ -206,7 +206,9 @@ export function useCallLifecycle(callObject, roomUrl, player) {
           console.warn("Failed to attempt AGC disable:", agcErr);
         }
       } catch (err) {
-        console.error("Error joining Daily room", roomUrl, err);
+        console.error("Error joining Daily room", roomUrl, err, {
+          meetingState: callObject.meetingState?.(),
+        });
       } finally {
         joiningMeetingRef.current = false;
       }
@@ -230,7 +232,7 @@ export function useCallLifecycle(callObject, roomUrl, player) {
         state === "loaded"
       ) {
         // only leave if we are in the process of joining or already joined
-        console.log("Leaving Daily room");
+        console.log("[VideoCall] Leaving Daily room", { state, roomUrl });
         callObject.leave();
       } else if (state === "joining") {
         console.warn("[VideoCall] Cleanup: callObject is mid-join, leave() skipped", {

--- a/client/src/call/hooks/useCallLifecycle.js
+++ b/client/src/call/hooks/useCallLifecycle.js
@@ -78,8 +78,14 @@ export function useCallLifecycle(callObject, roomUrl, player) {
 
     const joinRoom = async () => {
       const meetingState = callObject.meetingState?.();
-      if (meetingState === "joined-meeting" || joiningMeetingRef.current)
+      if (meetingState === "joined-meeting" || joiningMeetingRef.current) {
+        console.warn("[VideoCall] joinRoom skipped — already in meeting or joining", {
+          meetingState,
+          joiningMeetingRef: joiningMeetingRef.current,
+          roomUrl,
+        });
         return;
+      }
 
       const joinStartTime = Date.now();
       joinStartTimeRef.current = joinStartTime;
@@ -192,6 +198,11 @@ export function useCallLifecycle(callObject, roomUrl, player) {
         // only leave if we are in the process of joining or already joined
         console.log("Leaving Daily room");
         callObject.leave();
+      } else if (state === "joining") {
+        console.warn("[VideoCall] Cleanup: callObject is mid-join, leave() skipped", {
+          state,
+          roomUrl,
+        });
       }
     };
     // `player` is intentionally excluded: position is read once at join time and

--- a/client/src/call/hooks/useCallStartSignaling.js
+++ b/client/src/call/hooks/useCallStartSignaling.js
@@ -109,6 +109,10 @@ export function useCallStartSignaling(callObject, recordingEnabled, stageId) {
 
     // If already joined (effect ran after joined-meeting fired), start immediately
     if (callObject.meetingState?.() === "joined-meeting") {
+      console.log("[Recording] Already joined at effect start, attempting recording", {
+        stageId,
+        meetingState: callObject.meetingState?.(),
+      });
       startRecordingIfNeeded();
     }
 

--- a/client/src/call/hooks/useCallStartSignaling.js
+++ b/client/src/call/hooks/useCallStartSignaling.js
@@ -84,7 +84,7 @@ export function useCallStartSignaling(callObject, recordingEnabled, stageId) {
             if (!recordingConfirmedRef.current) {
               Sentry.captureMessage("Recording not started for stage", {
                 level: "error",
-                extra: { triggeringError: "non-promise return after retry", stageId, trigger },
+                extra: { triggeringError: "non-promise return", stageId, trigger },
               });
             }
           }, 5000);

--- a/client/src/call/hooks/useCallStartSignaling.js
+++ b/client/src/call/hooks/useCallStartSignaling.js
@@ -31,44 +31,60 @@ export function useCallStartSignaling(callObject, recordingEnabled, stageId) {
     // Track deferred Sentry timers so we can cancel on cleanup
     const pendingTimers = [];
 
-    const startRecordingIfNeeded = () => {
-      if (recordingEnabled && !recordingStartedRef.current) {
-        recordingStartedRef.current = true;
-        const result = callObject.startRecording({ type: "raw-tracks" });
-        if (result && typeof result.then === "function") {
-          result.then(
-            () => console.log("[Recording] Started raw-tracks recording from client"),
-            (err) => {
-              console.warn("[Recording] Failed to start recording:", err.message);
-              recordingStartedRef.current = false;
+    const attemptStartRecording = (trigger, attempt = 1) => {
+      const result = callObject.startRecording({ type: "raw-tracks" });
+      if (result && typeof result.then === "function") {
+        result.then(
+          () => console.log("[Recording] Started raw-tracks recording from client", {
+            trigger, attempt,
+          }),
+          (err) => {
+            console.warn("[Recording] Failed to start recording:", err.message, {
+              trigger, attempt,
+            });
+            recordingStartedRef.current = false;
 
-              // Defer Sentry alert: wait 5s and check if another participant
-              // successfully started recording (indicated by recording-started
-              // event setting recordingConfirmedRef). This avoids false alarms
-              // when one client fails but another succeeds — Daily broadcasts
-              // recording-started to all participants regardless of who initiated.
-              const timer = setTimeout(() => {
-                if (!recordingConfirmedRef.current) {
-                  Sentry.captureMessage("Recording not started for stage", {
-                    level: "error",
-                    extra: { triggeringError: err.message, stageId },
-                  });
-                }
-              }, 5000);
-              pendingTimers.push(timer);
+            // Defer Sentry alert: wait 5s and check if another participant
+            // successfully started recording (indicated by recording-started
+            // event setting recordingConfirmedRef). This avoids false alarms
+            // when one client fails but another succeeds — Daily broadcasts
+            // recording-started to all participants regardless of who initiated.
+            const timer = setTimeout(() => {
+              if (!recordingConfirmedRef.current) {
+                Sentry.captureMessage("Recording not started for stage", {
+                  level: "error",
+                  extra: { triggeringError: err.message, stageId, trigger, attempt },
+                });
+              }
+            }, 5000);
+            pendingTimers.push(timer);
+          }
+        );
+      } else {
+        console.warn("[Recording] startRecording() returned non-Promise; call may be in transitional state", {
+          trigger, attempt, meetingState: callObject.meetingState?.(),
+        });
+        recordingStartedRef.current = false;
+
+        // Retry once after 500ms — Daily's recording API may not be ready
+        // at the same tick as joined-meeting (see DELIBERATION-EMPIRICA-RK).
+        if (attempt < 2) {
+          const retryTimer = setTimeout(() => {
+            if (!recordingConfirmedRef.current && !recordingStartedRef.current) {
+              console.log("[Recording] Retrying startRecording", { trigger, attempt: attempt + 1 });
+              recordingStartedRef.current = true;
+              attemptStartRecording(trigger, attempt + 1);
             }
-          );
+          }, 500);
+          pendingTimers.push(retryTimer);
         } else {
-          console.warn("[Recording] startRecording() returned non-Promise; call may be in transitional state");
-          recordingStartedRef.current = false;
-
           // Defer Sentry alert: if no participant confirms recording within 5s,
           // surface the issue so we don't silently miss a whole stage of recording.
           const timer = setTimeout(() => {
             if (!recordingConfirmedRef.current) {
               Sentry.captureMessage("Recording not started for stage", {
                 level: "error",
-                extra: { triggeringError: "non-promise return", stageId },
+                extra: { triggeringError: "non-promise return after retry", stageId, trigger },
               });
             }
           }, 5000);
@@ -77,8 +93,15 @@ export function useCallStartSignaling(callObject, recordingEnabled, stageId) {
       }
     };
 
+    const startRecordingIfNeeded = (trigger) => {
+      if (recordingEnabled && !recordingStartedRef.current) {
+        recordingStartedRef.current = true;
+        attemptStartRecording(trigger);
+      }
+    };
+
     const handleJoined = () => {
-      startRecordingIfNeeded();
+      startRecordingIfNeeded("joined-meeting-event");
     };
 
     const handleRecordingStarted = () => {
@@ -113,7 +136,7 @@ export function useCallStartSignaling(callObject, recordingEnabled, stageId) {
         stageId,
         meetingState: callObject.meetingState?.(),
       });
-      startRecordingIfNeeded();
+      startRecordingIfNeeded("already-joined-at-effect-start");
     }
 
     return () => {

--- a/client/src/components/ConditionalRender.jsx
+++ b/client/src/components/ConditionalRender.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { usePlayer, usePlayers } from "@empirica/core/player/classic/react";
+import { usePlayer, usePlayers, useStage } from "@empirica/core/player/classic/react";
 import { Loading } from "@empirica/core/player/react";
 import { isMobile } from "react-device-detect";
 import { detect } from "detect-browser";
@@ -160,9 +160,24 @@ function RecursiveConditionalRender({ conditions, children, fallback = null }) {
 export function SubmissionConditionalRender({ children }) {
   const player = usePlayer();
   const players = usePlayers();
+  const stage = useStage();
   const { setAllowIdle } = useIdleContext();
 
   const isSubmitted = player?.stage?.get("submit");
+
+  // Diagnostic: detect when player.stage and useStage() are out of sync.
+  // player.stage.id reflects the player's current stage assignment (updates first).
+  // stage.id from useStage() reflects the stage observable (updates second).
+  // When they differ, we're in the stale-data window that can cause spurious renders.
+  const playerStageId = player?.stage?.id;
+  const stageHookId = stage?.id;
+  if (playerStageId && stageHookId && playerStageId !== stageHookId) {
+    console.warn("[SubmissionConditionalRender] Stage desync detected", {
+      playerStageId,
+      stageHookId,
+      isSubmitted: !!isSubmitted,
+    });
+  }
 
   useEffect(() => {
     if (isSubmitted) {

--- a/client/src/components/ConditionalRender.jsx
+++ b/client/src/components/ConditionalRender.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { usePlayer, usePlayers, useStage } from "@empirica/core/player/classic/react";
+import { usePlayer, usePlayers } from "@empirica/core/player/classic/react";
 import { Loading } from "@empirica/core/player/react";
 import { isMobile } from "react-device-detect";
 import { detect } from "detect-browser";
@@ -160,24 +160,9 @@ function RecursiveConditionalRender({ conditions, children, fallback = null }) {
 export function SubmissionConditionalRender({ children }) {
   const player = usePlayer();
   const players = usePlayers();
-  const stage = useStage();
   const { setAllowIdle } = useIdleContext();
 
   const isSubmitted = player?.stage?.get("submit");
-
-  // Diagnostic: detect when player.stage and useStage() are out of sync.
-  // player.stage.id reflects the player's current stage assignment (updates first).
-  // stage.id from useStage() reflects the stage observable (updates second).
-  // When they differ, we're in the stale-data window that can cause spurious renders.
-  const playerStageId = player?.stage?.id;
-  const stageHookId = stage?.id;
-  if (playerStageId && stageHookId && playerStageId !== stageHookId) {
-    console.warn("[SubmissionConditionalRender] Stage desync detected", {
-      playerStageId,
-      stageHookId,
-      isSubmitted: !!isSubmitted,
-    });
-  }
 
   useEffect(() => {
     if (isSubmitted) {

--- a/playwright/component-tests/video-call/mocked/OrphanedJoin.ct.jsx
+++ b/playwright/component-tests/video-call/mocked/OrphanedJoin.ct.jsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { test, expect } from '@playwright/experimental-ct-react';
+import { VideoCall } from '../../../../client/src/call/VideoCall';
+
+/**
+ * Component Tests for Orphaned Daily Join Race Condition (Issue #1226)
+ *
+ * Tests: ORPHAN-001 to ORPHAN-003
+ *
+ * The race condition: During Empirica stage transitions, a ~70ms desync window
+ * can cause VideoCall to mount spuriously on a non-video stage. It calls
+ * callObject.join(), then unmounts when the stage data resolves. But cleanup
+ * skips leave() when meetingState is "joining", so the join completes orphaned
+ * and the callObject is stuck in "joined-meeting" on the wrong room.
+ *
+ * Infrastructure:
+ * - window.__mockInitialMeetingState: set BEFORE mount to override initial state
+ * - window.__mockJoinBehavior: 'delayed' makes join() return a manually-resolvable promise
+ * - window.mockCallObject._resolveJoin(): resolve the pending delayed join
+ * - window.mockCallObject._leaveCalls: array of leave() call logs
+ */
+
+const baseConfig = {
+  empirica: {
+    currentPlayerId: 'p0',
+    players: [{ id: 'p0', attrs: { position: '0', dailyId: 'daily-p0', name: 'Test User' } }],
+    game: { attrs: { dailyUrl: 'https://test.daily.co/room-a' } },
+    stage: { attrs: {}, id: 'stage-1' },
+    stageTimer: { elapsed: 0 },
+  },
+  daily: {
+    localSessionId: 'daily-p0',
+    participantIds: ['daily-p0'],
+    videoTracks: { 'daily-p0': { isOff: false, subscribed: true } },
+    audioTracks: { 'daily-p0': { isOff: false, subscribed: true } },
+  },
+};
+
+test.describe('Orphaned Join Cleanup (useCallLifecycle)', () => {
+  /**
+   * ORPHAN-001: When component unmounts during "joining" state, leave() must be
+   * called after the join completes.
+   *
+   * This is the core bug from issue #1226:
+   * 1. VideoCall mounts spuriously during stage desync window
+   * 2. callObject.join() starts (meetingState → "joining")
+   * 3. Component unmounts when stage data resolves (not a video stage)
+   * 4. Cleanup sees "joining" and skips leave()  ← BUG
+   * 5. Join completes → callObject stuck in "joined-meeting" on wrong room
+   *
+   * Expected: cleanup arranges for leave() after the pending join resolves.
+   *
+   * STATUS: RED test — fails with current code, passes after fix.
+   */
+  test('ORPHAN-001: leave() called after orphaned join completes on unmount', async ({ mount, page }) => {
+    // Setup: delayed join so we can unmount while "joining"
+    await page.evaluate(() => {
+      window.__mockInitialMeetingState = 'new';
+      window.__mockJoinBehavior = 'delayed';
+    });
+
+    const component = await mount(<VideoCall showSelfView />, {
+      hooksConfig: baseConfig,
+    });
+
+    // Wait for join to start (state should transition to 'joining')
+    await expect(async () => {
+      const state = await page.evaluate(() => window.mockCallObject?.meetingState());
+      expect(state).toBe('joining');
+    }).toPass({ timeout: 3000 });
+
+    // Save reference to mock before unmount (provider cleanup deletes window.mockCallObject)
+    await page.evaluate(() => {
+      window._savedMock = window.mockCallObject;
+    });
+
+    // Verify no leave() calls yet
+    const leavesBefore = await page.evaluate(() => window._savedMock._leaveCalls.length);
+    expect(leavesBefore).toBe(0);
+
+    // Unmount while join is in progress — this is the critical moment.
+    // Current behavior: cleanup sees "joining", skips leave() → BUG
+    // Fixed behavior: cleanup arranges for leave() after join resolves
+    await component.unmount();
+
+    // Resolve the pending join (simulates Daily SDK completing the join)
+    await page.evaluate(() => window._savedMock._resolveJoin());
+
+    // Give the post-join cleanup a tick to run
+    await page.waitForTimeout(100);
+
+    // Verify leave() was called after the orphaned join completed
+    const leaveCalls = await page.evaluate(() => window._savedMock._leaveCalls);
+    expect(leaveCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  /**
+   * ORPHAN-002: Normal unmount from "joined-meeting" calls leave() immediately.
+   *
+   * Regression test: existing cleanup behavior must not break.
+   */
+  test('ORPHAN-002: normal cleanup calls leave() when joined', async ({ mount, page }) => {
+    const component = await mount(<VideoCall showSelfView />, {
+      hooksConfig: baseConfig,
+    });
+    await expect(component).toBeVisible({ timeout: 15000 });
+
+    // Save reference before unmount
+    await page.evaluate(() => {
+      window._savedMock = window.mockCallObject;
+    });
+
+    // Unmount — cleanup should call leave() since state is "joined-meeting"
+    await component.unmount();
+
+    const leaveCalls = await page.evaluate(() => window._savedMock._leaveCalls);
+    expect(leaveCalls.length).toBeGreaterThanOrEqual(1);
+    expect(leaveCalls[0].fromState).toBe('joined-meeting');
+  });
+
+  /**
+   * ORPHAN-003: joinRoom skips when callObject is already in "joined-meeting".
+   *
+   * Existing guard behavior — join() should NOT be called redundantly.
+   */
+  test('ORPHAN-003: joinRoom skips when already joined', async ({ mount, page }) => {
+    const component = await mount(<VideoCall showSelfView />, {
+      hooksConfig: baseConfig,
+    });
+    await expect(component).toBeVisible({ timeout: 15000 });
+
+    // Mock starts in "joined-meeting" — joinRoom() should have skipped join()
+    const joinCalled = await page.evaluate(() => window.mockCallObject._joinCalled);
+    expect(joinCalled).toBe(false);
+  });
+});

--- a/playwright/component-tests/video-call/mocked/OrphanedJoin.ct.jsx
+++ b/playwright/component-tests/video-call/mocked/OrphanedJoin.ct.jsx
@@ -49,8 +49,6 @@ test.describe('Orphaned Join Cleanup (useCallLifecycle)', () => {
    * 5. Join completes → callObject stuck in "joined-meeting" on wrong room
    *
    * Expected: cleanup arranges for leave() after the pending join resolves.
-   *
-   * STATUS: RED test — fails with current code, passes after fix.
    */
   test('ORPHAN-001: leave() called after orphaned join completes on unmount', async ({ mount, page }) => {
     // Setup: delayed join so we can unmount while "joining"

--- a/playwright/mocks/daily/MockDailyProvider.jsx
+++ b/playwright/mocks/daily/MockDailyProvider.jsx
@@ -107,6 +107,11 @@ class MockCallObject extends MockEventEmitter {
         };
       });
     }
+    // Non-delayed join: immediately transition to joined and emit event
+    if (this._meetingState !== 'joined-meeting') {
+      this._meetingState = 'joined-meeting';
+      this.emit('joined-meeting', {});
+    }
     return Promise.resolve();
   }
 

--- a/playwright/mocks/daily/MockDailyProvider.jsx
+++ b/playwright/mocks/daily/MockDailyProvider.jsx
@@ -68,7 +68,8 @@ class MockEventEmitter {
 class MockCallObject extends MockEventEmitter {
   constructor() {
     super();
-    this._meetingState = 'joined-meeting';
+    // Allow pre-configuration of initial meeting state (default: 'joined-meeting')
+    this._meetingState = (typeof window !== 'undefined' && window.__mockInitialMeetingState) || 'joined-meeting';
     this._updateParticipantsCalls = [];
     this._setInputDevicesCalls = []; // eslint-disable-line no-underscore-dangle
     this._participants = {};
@@ -79,7 +80,9 @@ class MockCallObject extends MockEventEmitter {
     this._localUserData = null;   // userData passed in join() options
     this._localSessionId = null;  // session ID of local participant (set via setLocalSessionId)
     this._joinCalled = false;     // tracks whether join() was called (for rejoin tests)
+    this._leaveCalls = [];        // tracks leave() calls for lifecycle tests
     this._startRecordingCalls = []; // tracks startRecording() calls for recording tests
+    this._resolveJoin = null;     // manually resolve a delayed join (set by join() when delayed)
     // Allow pre-configuration via window global (set before mount in tests)
     this._startRecordingBehavior = (typeof window !== 'undefined' && window.__mockStartRecordingBehavior) || 'resolve';
   }
@@ -92,10 +95,26 @@ class MockCallObject extends MockEventEmitter {
     if (options.userData) {
       this._localUserData = options.userData;
     }
+    // Support delayed join for lifecycle tests (orphaned join race condition)
+    const behavior = typeof window !== 'undefined' && window.__mockJoinBehavior;
+    if (behavior === 'delayed') {
+      this._meetingState = 'joining';
+      return new Promise((resolve) => {
+        this._resolveJoin = () => {
+          this._meetingState = 'joined-meeting';
+          resolve();
+          this.emit('joined-meeting', {});
+        };
+      });
+    }
     return Promise.resolve();
   }
 
-  leave() { return Promise.resolve(); }
+  leave() {
+    this._leaveCalls.push({ timestamp: Date.now(), fromState: this._meetingState });
+    this._meetingState = 'left-meeting';
+    return Promise.resolve();
+  }
 
   startRecording(options) {
     this._startRecordingCalls.push({ options, timestamp: Date.now() });


### PR DESCRIPTION
## Summary

- **Debounce Daily join by 150ms** to prevent spurious joins during transient VideoCall mounts at stage transitions
- **Orphaned join detection**: if component unmounts while `callObject.join()` is in flight, call `leave()` after join completes
- **Guard joinRoom against all in-progress states**: skip join when meetingState is `"joining"` or `"joined-meeting"`
- **Retry `startRecording` once after 500ms** when it returns a non-Promise (Daily API may not be ready at the same tick as `joined-meeting`)
- **Remove broken desync diagnostic** from `SubmissionConditionalRender` (was comparing independent ULIDs that could never match)

## Root cause

During stage transitions, Empirica can briefly render a VideoCall component (~36ms) for a non-video stage before React reconciliation unmounts it. In that window, `useCallLifecycle` fires `callObject.join()`. The component then unmounts, but cleanup can't call `leave()` because meetingState is `"joining"`. The join completes ~1.3s later on a non-video stage, and the callObject is left in `"joined-meeting"`. When the next video stage mounts and calls `join()` on a callObject that's mid-`leave()` from the orphaned cleanup, the Daily SDK enters a broken state — causing missing audio, failed recordings, and `startRecording()` returning `undefined`.

The 150ms debounce prevents the join from ever firing during transient mounts. The orphaned join detection is a safety net for any join that gets past the debounce.

See #1226 for the full investigation.

## Key files

- `client/src/call/hooks/useCallLifecycle.js` — debounce + orphaned join detection + improved guards
- `client/src/call/hooks/useCallStartSignaling.js` �� recording retry logic
- `playwright/mocks/daily/MockDailyProvider.jsx` — delayed join + leave tracking for tests
- `playwright/component-tests/video-call/mocked/OrphanedJoin.ct.jsx` — new lifecycle tests

## Test plan

- [ ] `npm run lint` passes
- [ ] Playwright component tests pass
- [ ] Deploy and monitor Sentry breadcrumbs — look for:
  - `[VideoCall] Join debounce: component unmounted during delay` (fix working)
  - `[VideoCall] Orphaned join detected` (safety net triggered — shouldn't happen with debounce)
  - Absence of `Recording not started for stage` errors

Closes #1226
Ref: #1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)