### PR TITLE
fix(qualtrics): forward urlParams prop through Element wrapper

### DIFF
--- a/client/src/elements/Element.jsx
+++ b/client/src/elements/Element.jsx
@@ -49,11 +49,10 @@ export function Element({ element, onSubmit }) {
       );
 
     case "qualtrics":
-      console.log("qualtrics");
       return (
         <Qualtrics
           url={element.url}
-          params={element.params}
+          urlParams={element.urlParams}
           onSubmit={onSubmit}
         />
       );

--- a/playwright/component-tests/elements/Qualtrics.ct.jsx
+++ b/playwright/component-tests/elements/Qualtrics.ct.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { test, expect } from '@playwright/experimental-ct-react';
-import { QualtricsStory } from './QualtricsStory';
+import { QualtricsStory, QualtricsElementStory } from './QualtricsStory';
 
 /**
  * Component Tests for Qualtrics URL Parameter Resolution
@@ -193,6 +193,31 @@ test('QURL-005: mixed static and reference params both appear in URL', async ({ 
   // Always-present params unaffected
   expect(url.searchParams.get('deliberationId')).toBe('delib-abc-123');
   expect(url.searchParams.get('sampleId')).toBe('sample-xyz-456');
+});
+
+/**
+ * Test ID: QURL-007
+ * Regression: Element.jsx was passing `params={element.params}` to Qualtrics
+ * while the component (and YAML schema) use the name `urlParams`, so nothing
+ * got through the wrapper even when the treatment file was correct. Mounting
+ * via Element catches that prop-name mismatch; the other QURL tests bypass it.
+ */
+test('QURL-007: Element wrapper forwards urlParams to Qualtrics', async ({ mount }) => {
+  const component = await mount(
+    <QualtricsElementStory
+      url={SURVEY_URL}
+      urlParams={[
+        { key: 'participantType', value: 'pilot' },
+        { key: 'sessionType', value: 'A' },
+      ]}
+    />,
+    { hooksConfig: { empirica: baseEmpirica } },
+  );
+
+  const src = await component.locator('[data-test="qualtricsIframe"]').getAttribute('src');
+  const url = new URL(src);
+  expect(url.searchParams.get('participantType')).toBe('pilot');
+  expect(url.searchParams.get('sessionType')).toBe('A');
 });
 
 /**

--- a/playwright/component-tests/elements/QualtricsStory.jsx
+++ b/playwright/component-tests/elements/QualtricsStory.jsx
@@ -17,6 +17,7 @@
  */
 import React from 'react';
 import { Qualtrics } from '../../../client/src/elements/Qualtrics';
+import { Element } from '../../../client/src/elements/Element';
 import { IdleProvider } from '../../../client/src/components/IdleProvider';
 
 export function QualtricsStory({ url, urlParams }) {
@@ -26,6 +27,20 @@ export function QualtricsStory({ url, urlParams }) {
   return (
     <IdleProvider>
       <Qualtrics url={url} urlParams={urlParams} onSubmit={handleSubmit} />
+    </IdleProvider>
+  );
+}
+
+// Routes through Element.jsx's switch statement — the layer where the
+// `element.params` vs `element.urlParams` bug (issue #1211 follow-up) lived.
+export function QualtricsElementStory({ url, urlParams }) {
+  const handleSubmit = () => {};
+  return (
+    <IdleProvider>
+      <Element
+        element={{ type: 'qualtrics', url, urlParams }}
+        onSubmit={handleSubmit}
+      />
     </IdleProvider>
   );
 }


### PR DESCRIPTION
## Summary
- `Element.jsx` was passing `params={element.params}` to the `<Qualtrics>` component, but both the YAML schema and the component itself use the name `urlParams` — so `resolvedParams` was always `[]` and **no** configured URL params reached the iframe (only the always-appended `deliberationId` / `sampleId` got through).
- The companion `trackedLink` case in the same switch already wires it correctly; this brings Qualtrics to the same pattern.
- Adds **QURL-007** mounting `Qualtrics` via `Element.jsx` to cover the wrapper layer. The existing QURL-001…006 all mount `<Qualtrics>` directly via `QualtricsStory`, which is why this regressed silently after #1217.

Surfaced by a researcher whose treatment file correctly declared `urlParams` (with both a static `value` and a dynamic `reference`) but saw neither one appear in the iframe URL.

## Test plan
- [x] `npx playwright test --config playwright/playwright.config.mjs "elements/Qualtrics"` — 21/21 pass (chromium/firefox/webkit)
- [x] Verified QURL-007 fails on the buggy pre-fix code (confirmed with a temporary revert)
- [x] `npm run lint` — no new errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)